### PR TITLE
[REFACTOR] 필터 구조 리팩토링 (#159)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -34,9 +34,10 @@
 		1547A8802D358E2700E96616 /* SpotListFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547A87F2D358E2700E96616 /* SpotListFilterView.swift */; };
 		1547A8822D358E3000E96616 /* SpotListFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547A8812D358E3000E96616 /* SpotListFilterViewController.swift */; };
 		1547A8852D3595B600E96616 /* SpotListFilterModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547A8842D3595B600E96616 /* SpotListFilterModel.swift */; };
-		1547A88B2D3596B600E96616 /* SpotType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547A88A2D3596B600E96616 /* SpotType.swift */; };
+		1547A88B2D3596B600E96616 /* SpotFilterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547A88A2D3596B600E96616 /* SpotFilterType.swift */; };
 		1547A88E2D35B13700E96616 /* FilterTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547A88D2D35B13700E96616 /* FilterTagButton.swift */; };
 		1547A8902D35B30C00E96616 /* FilterTagButtonType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547A88F2D35B30C00E96616 /* FilterTagButtonType.swift */; };
+		1549976D2DEC51C80040242F /* SpotType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1549976C2DEC51C80040242F /* SpotType.swift */; };
 		1558BA1A2D318FFC00ECDEF8 /* ACTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1558BA192D318FFC00ECDEF8 /* ACTabBarController.swift */; };
 		1558BADB2D31AAF900ECDEF8 /* ACTabBarItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1558BADA2D31AAF900ECDEF8 /* ACTabBarItemType.swift */; };
 		1558BADE2D31AB6C00ECDEF8 /* SpotListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1558BADD2D31AB6C00ECDEF8 /* SpotListViewController.swift */; };
@@ -292,9 +293,10 @@
 		1547A87F2D358E2700E96616 /* SpotListFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListFilterView.swift; sourceTree = "<group>"; };
 		1547A8812D358E3000E96616 /* SpotListFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListFilterViewController.swift; sourceTree = "<group>"; };
 		1547A8842D3595B600E96616 /* SpotListFilterModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListFilterModel.swift; sourceTree = "<group>"; };
-		1547A88A2D3596B600E96616 /* SpotType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotType.swift; sourceTree = "<group>"; };
+		1547A88A2D3596B600E96616 /* SpotFilterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotFilterType.swift; sourceTree = "<group>"; };
 		1547A88D2D35B13700E96616 /* FilterTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTagButton.swift; sourceTree = "<group>"; };
 		1547A88F2D35B30C00E96616 /* FilterTagButtonType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTagButtonType.swift; sourceTree = "<group>"; };
+		1549976C2DEC51C80040242F /* SpotType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotType.swift; sourceTree = "<group>"; };
 		1558BA192D318FFC00ECDEF8 /* ACTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACTabBarController.swift; sourceTree = "<group>"; };
 		1558BADA2D31AAF900ECDEF8 /* ACTabBarItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACTabBarItemType.swift; sourceTree = "<group>"; };
 		1558BADD2D31AB6C00ECDEF8 /* SpotListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListViewController.swift; sourceTree = "<group>"; };
@@ -620,6 +622,7 @@
 		1547A8742D354E2900E96616 /* Type */ = {
 			isa = PBXGroup;
 			children = (
+				1549976C2DEC51C80040242F /* SpotType.swift */,
 				15A3F6A52D36C49F00577E16 /* SpotListItemSizeType.swift */,
 				15A246132DE79D7E00469272 /* NoMatchingSpotType.swift */,
 				156AE6782DE0F1D300AE800D /* NoMatchingSpotListItemSizeType.swift */,
@@ -661,7 +664,7 @@
 		1547A8892D3596A400E96616 /* Type */ = {
 			isa = PBXGroup;
 			children = (
-				1547A88A2D3596B600E96616 /* SpotType.swift */,
+				1547A88A2D3596B600E96616 /* SpotFilterType.swift */,
 				1547A88F2D35B30C00E96616 /* FilterTagButtonType.swift */,
 				15A3F6A72D36D5B900577E16 /* FilterTagButtonStackLineType.swift */,
 			);
@@ -1800,9 +1803,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ACON-iOS/Pods-ACON-iOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ACON-iOS/Pods-ACON-iOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1825,6 +1832,7 @@
 				15A48BFA2D574BA5003C2421 /* ProfileEditView.swift in Sources */,
 				74BF92272D39957600B923E3 /* StickyHeaderView.swift in Sources */,
 				151003EC2D5FBF7200409DF4 /* GetProfileResponse.swift in Sources */,
+				1549976D2DEC51C80040242F /* SpotType.swift in Sources */,
 				151AB6C92DD3E64600D01DE8 /* MenuImageSlideViewController.swift in Sources */,
 				1530CC7B2DDFD36900EB4AEC /* TempSpotListErrorView.swift in Sources */,
 				746F15B92D3E212D003EA031 /* PostLocalAreaResponse.swift in Sources */,
@@ -2006,7 +2014,7 @@
 				7462618B2D3FA4A800A4E84F /* SpotDetailService.swift in Sources */,
 				748D6F992D2BD54E007690B4 /* DummyProtocol.swift in Sources */,
 				74D297F22D63436F00DDEE31 /* GetPresignedURLResponse.swift in Sources */,
-				1547A88B2D3596B600E96616 /* SpotType.swift in Sources */,
+				1547A88B2D3596B600E96616 /* SpotFilterType.swift in Sources */,
 				74BF92172D393B4A00B923E3 /* Int+.swift in Sources */,
 				747BB6CE2DCA66F000352874 /* GlassButtonState.swift in Sources */,
 				15CF62BD2D575EC00000A10F /* ProfileEditValidMessageView.swift in Sources */,

--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -240,7 +240,7 @@ enum StringLiterals {
         
         static let kind = "종류"
         
-        static let operatingHours = "운영시간"
+        static let openingHours = "운영시간"
         
         static let priceSection = "가격"
         

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotType.swift
@@ -1,0 +1,42 @@
+//
+//  SpotType.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 6/1/25.
+//
+
+import Foundation
+
+enum SpotType {
+
+    case restaurant, cafe
+
+    var text: String {
+        switch self {
+        case .restaurant: return "음식점"
+        case .cafe: return "카페"
+        }
+    }
+
+    var serverKey: String {
+        switch self {
+        case .restaurant: return "RESTAURANT"
+        case .cafe: return "CAFE"
+        }
+    }
+
+    var firstLineCount: Int {
+        switch self {
+        case .restaurant: return 5
+        case .cafe: return 2
+        }
+    }
+
+    var secondLineCount: Int {
+        switch self {
+        case .restaurant: return 4
+        case .cafe: return 0
+        }
+    }
+
+}

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotType.swift
@@ -34,8 +34,8 @@ enum SpotType {
 
     var secondLineCount: Int {
         switch self {
-        case .restaurant: return 4 + firstLineCount
-        case .cafe: return 0 + firstLineCount
+        case .restaurant: return 4
+        case .cafe: return 0
         }
     }
 

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotType.swift
@@ -34,8 +34,8 @@ enum SpotType {
 
     var secondLineCount: Int {
         switch self {
-        case .restaurant: return 4
-        case .cafe: return 0
+        case .restaurant: return 4 + firstLineCount
+        case .cafe: return 0 + firstLineCount
         }
     }
 

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/Model/SpotListFilterModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/Model/SpotListFilterModel.swift
@@ -21,7 +21,7 @@ struct SpotConditionModel: Equatable {
 
 struct SpotFilterModel: Equatable {
     
-    let category: SpotType.FilterCategoryType
+    let category: SpotFilterType
     
     let optionList: [String]
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/Type/SpotFilterType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/Type/SpotFilterType.swift
@@ -1,5 +1,5 @@
 //
-//  SpotType.swift
+//  SpotFilterType.swift
 //  ACON-iOS
 //
 //  Created by 김유림 on 1/14/25.
@@ -7,56 +7,34 @@
 
 import Foundation
 
-enum SpotType {
-    
-    // MARK: - 장소 종류
-    
-    case restaurant, cafe
-    
-    var text: String {
-        switch self {
-        case .restaurant: return "음식점"
-        case .cafe: return "카페"
-        }
-    }
-    
+// MARK: - 필터 카테고리
+
+enum SpotFilterType {
+
+    case restaurantFeature, cafeFeature, openingHours, price
+
     var serverKey: String {
         switch self {
-        case .restaurant: return "RESTAURANT"
-        case .cafe: return "CAFE"
+        case .restaurantFeature: return "RESTAURANT_FEATURE"
+        case .cafeFeature: return "CAFE_FEATURE"
+        case .openingHours: return "OPENING_HOURS"
+        case .price: return "PRICE"
         }
     }
 
-    var firstLineCount: Int { // TODO: 관련 코드 수정
-        switch self {
-        case .restaurant: return 5
-        case .cafe: return 2
-        }
-    }
+}
 
 
-    // MARK: - 필터 조건 타입
+// MARK: - 필터 옵션
+
+extension SpotFilterType {
+
+    // MARK: - Restaurant
     
-    enum FilterCategoryType: CaseIterable {
-        
-        case restaurantFeature, cafeFeature
-        
-        var serverKey: String {
-            switch self {
-            case .restaurantFeature: return "RESTAURANT_FEATURE"
-            case .cafeFeature: return "CAFE_FEATURE"
-            }
-        }
-        
-    }
+    enum RestaurantOptionType: CaseIterable {
 
+        case korean, chinese, japanese, western, asian, fusion, koreanStreet, buffet, bar, excludeFranchise
 
-    // MARK: - 장소 상세 조건
-    
-    enum RestaurantFeatureType: CaseIterable {
-        
-        case korean, chinese, japanese, western, asian, fusion, koreanStreet, buffet, bar
-        
         var text: String {
             switch self {
             case .korean: return "한식"
@@ -68,47 +46,55 @@ enum SpotType {
             case .koreanStreet: return "분식"
             case .buffet: return "뷔페"
             case .bar: return "술/bar"
+            case .excludeFranchise: return "프랜차이즈 제외"
             }
         }
-        
+
         var serverKey: String {
             switch self {
             case .korean: return "KOREAN"
             case .chinese: return "CHINESE"
             case .japanese: return "JAPANESE"
             case .western: return "WESTERN"
-            case .asian: return "ASIAN"
+            case .asian: return "SOUTHEAST_ASIAN"
             case .fusion: return "FUSION"
-            case .koreanStreet: return "KOREAN_STREET"
+            case .koreanStreet: return "BUNSIK"
             case .buffet: return "BUFFET"
-            case .bar: return "BAR"
+            case .bar: return "DRINKING_PLACE"
+            case .excludeFranchise: return "EXCLUDE_FRANCHISE"
             }
         }
-        
+
     }
-    
-    enum CafeFeatureType: CaseIterable {
-        
+
+
+    // MARK: - Cafe
+
+    enum CafeOptionType: CaseIterable {
+
         case goodForWork, excludeFranchise
-        
+
         var text: String {
             switch self {
             case .goodForWork: return "작업하기 좋은 곳"
             case .excludeFranchise: return "프랜차이즈 제외"
             }
         }
-        
+
         var serverKey: String {
             switch self {
-            case .goodForWork: return "GOOD_FOR_WORK" // TODO: 명세 나오면 수정
+            case .goodForWork: return "WORK_FRIENDLY"
             case .excludeFranchise: return "EXCLUDE_FRANCHISE"
             }
         }
-        
+
     }
-    
-    enum OperatingHours: CaseIterable {
-        
+
+
+    // MARK: - OpeningHours
+
+    enum OpeningHoursOptionType: CaseIterable {
+
         case overMidnight, overTenPM
         
         var text: String {
@@ -117,14 +103,34 @@ enum SpotType {
             case .overTenPM: return "밤 10시 이후"
             }
         }
-        
-        // TODO: 명세 나오면 수정하기
+
         var serverKey: String {
             switch self {
-            case .overMidnight: return "MIDNIGHT"
-            case .overTenPM: return "TEN_PM"
+            case .overMidnight: return "OPEN_AFTER_MIDNIGHT"
+            case .overTenPM: return "OPEN_AFTER_10PM"
+            }
+        }
+
+    }
+
+
+    // MARK: - Price
+
+    enum PriceOptionType: CaseIterable {
+
+        case goodPrice
+
+        var text: String {
+            switch self {
+            case .goodPrice: return StringLiterals.SpotListFilter.goodPricePlace
+            }
+        }
+
+        var serverKey: String {
+            switch self {
+            case .goodPrice: return "VALUE_FOR_MONEY"
             }
         }
     }
-    
+
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/Component/FilterTagButton.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/Component/FilterTagButton.swift
@@ -9,7 +9,14 @@ import UIKit
 
 class FilterTagButton: ACButton {
 
-    var isTagged: Bool = false
+    var isTagged: Bool = false {
+        didSet {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                updateGlassButtonState(state: isTagged ? .selected : .default)
+            }
+        }
+    }
 
     init() {
         super.init(style: GlassConfigButton(glassmorphismType: .buttonGlassDefault, buttonType: .full_19_b1R))
@@ -20,6 +27,8 @@ class FilterTagButton: ACButton {
 
         self.addTarget(self, action: #selector(toggleSelf), for: .touchUpInside)
         self.addTarget(self, action: #selector(touchDownSelf), for: .touchDown)
+        self.addTarget(self, action: #selector(touchUpOutsideSelf), for: .touchUpOutside)
+        self.addTarget(self, action: #selector(touchCancelSelf), for: .touchCancel)
     }
 
     @MainActor required init?(coder: NSCoder) {
@@ -29,12 +38,21 @@ class FilterTagButton: ACButton {
     @objc
     func toggleSelf(_ sender: UIButton) {
         isTagged.toggle()
-        updateGlassButtonState(state: isTagged ? .selected : .default)
     }
 
     @objc
     func touchDownSelf(_ sender: UIButton) {
         updateGlassButtonState(state: .pressed)
+    }
+    
+    @objc
+    func touchUpOutsideSelf(_ sender: UIButton) {
+        updateGlassButtonState(state: .default)
+    }
+
+    @objc
+    func touchCancelSelf(_ sender: UIButton) {
+        updateGlassButtonState(state: .default)
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/Component/FilterTagButton.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/Component/FilterTagButton.swift
@@ -67,12 +67,12 @@ private extension FilterTagButton {
     
     @objc
     func touchUpOutsideSelf(_ sender: UIButton) {
-        updateGlassButtonState(state: .default)
+        updateGlassButtonState(state: isTagged ? .selected : .default)
     }
 
     @objc
     func touchCancelSelf(_ sender: UIButton) {
-        updateGlassButtonState(state: .default)
+        updateGlassButtonState(state: isTagged ? .selected : .default)
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/Component/FilterTagButton.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/Component/FilterTagButton.swift
@@ -9,14 +9,23 @@ import UIKit
 
 class FilterTagButton: ACButton {
 
+    // MARK: - Properties
+
+    var onStateChanged: ((Bool) -> Void)?
+
     var isTagged: Bool = false {
         didSet {
+            onStateChanged?(isTagged)
+
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 updateGlassButtonState(state: isTagged ? .selected : .default)
             }
         }
     }
+
+
+    // MARK: - init
 
     init() {
         super.init(style: GlassConfigButton(glassmorphismType: .buttonGlassDefault, buttonType: .full_19_b1R))
@@ -25,15 +34,26 @@ class FilterTagButton: ACButton {
             self.updateGlassButtonState(state: .default)
         }
 
+        addTargets()
+    }
+
+    @MainActor required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func addTargets() {
         self.addTarget(self, action: #selector(toggleSelf), for: .touchUpInside)
         self.addTarget(self, action: #selector(touchDownSelf), for: .touchDown)
         self.addTarget(self, action: #selector(touchUpOutsideSelf), for: .touchUpOutside)
         self.addTarget(self, action: #selector(touchCancelSelf), for: .touchCancel)
     }
 
-    @MainActor required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+}
+
+
+// MARK: - objc functions
+
+private extension FilterTagButton {
 
     @objc
     func toggleSelf(_ sender: UIButton) {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/Component/SpotFilterTagStackView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/Component/SpotFilterTagStackView.swift
@@ -8,46 +8,34 @@
 import UIKit
 
 class SpotFilterTagStackView: UIStackView {
-    
-    // MARK: - LifeCycle
-    
+
+    // MARK: - LifeCycles
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         setStyle()
     }
-    
+
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     private func setStyle() {
         self.axis = .horizontal
         self.spacing = 8
     }
-    
+
 }
 
 
 // MARK: - StackView Control Methods
 
 extension SpotFilterTagStackView {
-    
+
     // MARK: - Internal Methods
-    
+
     func addTagButtons(titles: [String]) {
-        for title in titles {
-            let button = FilterTagButton()
-            button.setAttributedTitle(text: title, style: .b1R)
-            self.addArrangedSubview(button)
-        }
-        
-        addEmptyView()
-    }
-    
-    func switchTagButtons(titles: [String]) {
-        clearStackView()
-        
         for title in titles {
             let button = FilterTagButton()
             button.updateButtonTitle(title)
@@ -56,26 +44,19 @@ extension SpotFilterTagStackView {
         
         addEmptyView()
     }
-    
+
     func resetTagSelection() {
         self.arrangedSubviews.forEach { view in
             let button = view as? FilterTagButton ?? UIButton()
             button.isSelected = false
         }
     }
-    
-    
+
+
     // MARK: - Private Methods
-    
-    private func clearStackView() {
-        self.arrangedSubviews.forEach { view in
-            self.removeArrangedSubview(view)
-            view.removeFromSuperview()
-        }
-    }
-    
+
     private func addEmptyView() {
         self.addArrangedSubview(PriorityLowEmptyView())
     }
-    
+
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/Component/SpotFilterTagStackView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/Component/SpotFilterTagStackView.swift
@@ -9,11 +9,16 @@ import UIKit
 
 class SpotFilterTagStackView: UIStackView {
 
+    // MARK: - Properties
+
+    var tags: [FilterTagButton] = []
+
+
     // MARK: - LifeCycles
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         setStyle()
     }
 
@@ -29,33 +34,29 @@ class SpotFilterTagStackView: UIStackView {
 }
 
 
-// MARK: - StackView Control Methods
+// MARK: - Internal Methods
 
 extension SpotFilterTagStackView {
-
-    // MARK: - Internal Methods
 
     func addTagButtons(titles: [String]) {
         for title in titles {
             let button = FilterTagButton()
             button.updateButtonTitle(title)
             self.addArrangedSubview(button)
+            self.tags.append(button)
         }
         
         addEmptyView()
     }
 
-    func resetTagSelection() {
-        self.arrangedSubviews.forEach { view in
-            let button = view as? FilterTagButton ?? UIButton()
-            button.isSelected = false
-        }
-    }
+}
 
 
-    // MARK: - Private Methods
+// MARK: - Helper
 
-    private func addEmptyView() {
+private extension SpotFilterTagStackView {
+
+    func addEmptyView() {
         self.addArrangedSubview(PriorityLowEmptyView())
     }
 

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
@@ -36,6 +36,8 @@ class SpotListFilterView: GlassmorphismView {
     
     let secondLineSpotTagStackView = SpotFilterTagStackView()
     
+    let thirdLineSpotTagStackView = SpotFilterTagStackView()
+    
     
     // [Opening hours]: 운영 시간 (restaurant, cafe)
     
@@ -65,7 +67,6 @@ class SpotListFilterView: GlassmorphismView {
     // MARK: - Lifecycle
     
     init() {
-        // 🍇 TODO: 글모 Type 확인
         super.init(.bottomSheetGlass)
     }
 
@@ -102,7 +103,8 @@ class SpotListFilterView: GlassmorphismView {
         
         spotTagStackView.addArrangedSubviews(
             firstLineSpotTagStackView,
-            secondLineSpotTagStackView
+            secondLineSpotTagStackView,
+            thirdLineSpotTagStackView
         )
         
         
@@ -180,7 +182,6 @@ class SpotListFilterView: GlassmorphismView {
             $0.height.equalTo(44)
             $0.width.equalTo(200 * ScreenUtils.widthRatio)
         }
-
     }
     
     override func setStyle() {
@@ -200,11 +201,10 @@ class SpotListFilterView: GlassmorphismView {
         }
         
         setFooterUI()
-        setSpotSectionUI()
+        setSpotFeatureSectionUI()
         setOpeningHoursSectionUI()
         setPriceSectionUI()
     }
-    
 }
 
 
@@ -255,9 +255,9 @@ private extension SpotListFilterView {
     }
     
     
-    // MARK: - (Spot section)
+    // MARK: - (Spot feature section)
     
-    func setSpotSectionUI() {
+    func setSpotFeatureSectionUI() {
         spotSectionStackView.do {
             $0.axis = .vertical
             $0.spacing = innerSectionSpacing
@@ -285,6 +285,12 @@ private extension SpotListFilterView {
     // MARK: - (Price section)
     
     func setPriceSectionUI() {
+        priceSectionTitleLabel.setLabel(
+            text: StringLiterals.SpotListFilter.priceSection,
+            style: .t5SB)
+
+        goodPriceButton.updateButtonTitle(SpotFilterType.PriceOptionType.goodPrice.text)
+
         priceSectionView.isHidden = true
     }
     
@@ -295,7 +301,33 @@ private extension SpotListFilterView {
 
 extension SpotListFilterView {
 
-    func switchSpotTagStack(_ spotType: SpotType) {
+    func switchOptionTags(_ spotType: SpotType) {
+        switchSpotFeatureSection(spotType)
+        switchOpeningHoursSection(spotType)
+        switchPriceSection(spotType)
+    }
+
+    func resetAllTagSelection() {
+        [openingHoursButton, goodPriceButton].forEach { $0.isSelected = false }
+        [firstLineSpotTagStackView,
+         secondLineSpotTagStackView,
+         thirdLineSpotTagStackView].forEach {
+            $0.resetTagSelection()
+        }
+    }
+
+    func enableFooterButtons(_ isEnabled: Bool) {
+        [resetButton, conductButton].forEach { $0.isEnabled = isEnabled }
+    }
+
+}
+
+
+// MARK: - Helper (Switching option tags)
+
+private extension SpotListFilterView {
+
+    func switchSpotFeatureSection(_ spotType: SpotType) {
         let tagTexts: [String] = {
             switch spotType {
             case .restaurant:
@@ -304,34 +336,27 @@ extension SpotListFilterView {
                 return SpotFilterType.CafeOptionType.allCases.map { return $0.text }
             }
         }()
-
         let firstLine: [String] = Array(tagTexts[0..<spotType.firstLineCount])
-        let secondLine: [String] = Array(tagTexts[spotType.firstLineCount...])
+        let secondLine: [String] = Array(tagTexts[spotType.firstLineCount..<spotType.secondLineCount])
+        let thirdLine: [String] = Array(tagTexts[spotType.secondLineCount...])
+
         firstLineSpotTagStackView.switchTagButtons(titles: firstLine)
         secondLineSpotTagStackView.switchTagButtons(titles: secondLine)
-        
-        let openingHours: SpotFilterType.OpeningHoursOptionType = spotType == .restaurant ? .overMidnight : .overTenPM
-        openingHoursButton.updateButtonTitle(openingHours.text)
-        
+        thirdLineSpotTagStackView.switchTagButtons(titles: thirdLine)
+    }
+
+    func switchOpeningHoursSection(_ spotType: SpotType) {
+        let openingHoursOption: SpotFilterType.OpeningHoursOptionType = spotType == .restaurant ? .overMidnight : .overTenPM
+
+        openingHoursButton.updateButtonTitle(openingHoursOption.text)
+    }
+
+    func switchPriceSection(_ spotType: SpotType) {
         if spotType == .restaurant {
-            priceSectionTitleLabel.setLabel(
-                text: StringLiterals.SpotListFilter.priceSection,
-                style: .t5SB)
-            goodPriceButton.updateButtonTitle(StringLiterals.SpotListFilter.goodPricePlace)
             priceSectionView.isHidden = false
+        } else {
+            priceSectionView.isHidden = true
         }
-    }
-
-    func resetAllTagSelection() {
-        [openingHoursButton, goodPriceButton].forEach { $0.isSelected = false }
-        [firstLineSpotTagStackView,
-         secondLineSpotTagStackView].forEach {
-            $0.resetTagSelection()
-        }
-    }
-
-    func enableFooterButtons(_ isEnabled: Bool) {
-        [resetButton, conductButton].forEach { $0.isEnabled = isEnabled }
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
@@ -50,7 +50,7 @@ class SpotListFilterView: GlassmorphismView {
     
     private let openingHoursSectionTitleLabel = UILabel()
     
-    private let openingHoursButton = FilterTagButton()
+    let openingHoursButton = FilterTagButton()
     
     
     // [Price range]: 가격대 (restaurant, cafe)
@@ -59,7 +59,7 @@ class SpotListFilterView: GlassmorphismView {
     
     private let priceSectionTitleLabel = UILabel()
     
-    private let goodPriceButton = FilterTagButton()
+    let goodPriceButton = FilterTagButton()
     
     
     // MARK: - Size
@@ -290,8 +290,8 @@ private extension SpotListFilterView {
         case .restaurant:
             let options: [String] = SpotFilterType.RestaurantOptionType.allCases.map { return $0.text }
             let firstLine: [String] = Array(options[0..<spotType.firstLineCount])
-            let secondLine: [String] = Array(options[spotType.firstLineCount..<spotType.secondLineCount])
-            let thirdLine: [String] = Array(options[spotType.secondLineCount...])
+            let secondLine: [String] = Array(options[spotType.firstLineCount..<spotType.firstLineCount + spotType.secondLineCount])
+            let thirdLine: [String] = Array(options[(spotType.firstLineCount + spotType.secondLineCount)...])
 
             firstLineSpotTagStackView.addTagButtons(titles: firstLine)
             secondLineSpotTagStackView.addTagButtons(titles: secondLine)
@@ -299,6 +299,7 @@ private extension SpotListFilterView {
 
         case .cafe:
             let options: [String] = SpotFilterType.CafeOptionType.allCases.map { return $0.text }
+
             firstLineSpotTagStackView.addTagButtons(titles: options)
         }
     }
@@ -307,11 +308,10 @@ private extension SpotListFilterView {
     // MARK: - (Operating hours section)
     
     func setOpeningHoursSectionUI() {
-        openingHoursSectionTitleLabel.setLabel(text: StringLiterals.SpotListFilter.openingHours, style: .t5SB)
-        
-        let openingHoursOption: SpotFilterType.OpeningHoursOptionType = spotType == .restaurant ? .overMidnight : .overTenPM
+        let option: SpotFilterType.OpeningHoursOptionType = spotType == .restaurant ? .overMidnight : .overTenPM
 
-        openingHoursButton.updateButtonTitle(openingHoursOption.text)
+        openingHoursSectionTitleLabel.setLabel(text: StringLiterals.SpotListFilter.openingHours, style: .t5SB)
+        openingHoursButton.updateButtonTitle(option.text)
     }
 
 
@@ -336,15 +336,6 @@ private extension SpotListFilterView {
 // MARK: - Internal Methods (Update UI)
 
 extension SpotListFilterView {
-
-    func resetAllTagSelection() {
-        [openingHoursButton, goodPriceButton].forEach { $0.isSelected = false }
-        [firstLineSpotTagStackView,
-         secondLineSpotTagStackView,
-         thirdLineSpotTagStackView].forEach {
-            $0.resetTagSelection()
-        }
-    }
 
     func enableFooterButtons(_ isEnabled: Bool) {
         [resetButton, conductButton].forEach { $0.isEnabled = isEnabled }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
@@ -234,6 +234,8 @@ private extension SpotListFilterView {
             config.background.strokeWidth = 1
             $0.configuration = config
 
+            $0.isEnabled = false
+
             // NOTE: 상태 변경에 따라 UI 업데이트
             $0.configurationUpdateHandler = { button in
                 switch button.state {
@@ -251,6 +253,8 @@ private extension SpotListFilterView {
             var config = UIButton.Configuration.filled()
             config.cornerStyle = .capsule
             $0.configuration = config
+
+            $0.isEnabled = false
 
             // NOTE: 상태 변경에 따라 UI 업데이트
             $0.configurationUpdateHandler = { button in

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
@@ -19,9 +19,6 @@ class SpotListFilterView: GlassmorphismView {
     
     private let stackView = UIStackView()
     
-    // 🍇 TODO: 글모 Type 확인
-    private let footerView = GlassmorphismView(.buttonGlassDefault)
-    
     let resetButton = UIButton()
     
     let conductButton = LoadingAnimatedButton()
@@ -40,13 +37,13 @@ class SpotListFilterView: GlassmorphismView {
     let secondLineSpotTagStackView = SpotFilterTagStackView()
     
     
-    // [Operating hours]: 운영 시간 (restaurant, cafe)
+    // [Opening hours]: 운영 시간 (restaurant, cafe)
     
-    private let operatingHoursSectionView = UIView()
+    private let openingHoursSectionView = UIView()
     
-    private let operatingHoursSectionTitleLabel = UILabel()
+    private let openingHoursSectionTitleLabel = UILabel()
     
-    private let operatingHoursButton = FilterTagButton()
+    private let openingHoursButton = FilterTagButton()
     
     
     // [Price range]: 가격대 (restaurant, cafe)
@@ -91,7 +88,7 @@ class SpotListFilterView: GlassmorphismView {
         
         stackView.addArrangedSubviews(
             spotSectionStackView,
-            operatingHoursSectionView,
+            openingHoursSectionView,
             priceSectionView
         )
         
@@ -110,9 +107,9 @@ class SpotListFilterView: GlassmorphismView {
         
         
         // [Operating hours section]
-        operatingHoursSectionView.addSubviews(
-            operatingHoursSectionTitleLabel,
-            operatingHoursButton
+        openingHoursSectionView.addSubviews(
+            openingHoursSectionTitleLabel,
+            openingHoursButton
         )
         
         
@@ -149,12 +146,12 @@ class SpotListFilterView: GlassmorphismView {
             $0.centerX.equalToSuperview()
         }
         
-        operatingHoursSectionTitleLabel.snp.makeConstraints {
+        openingHoursSectionTitleLabel.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
         }
         
-        operatingHoursButton.snp.makeConstraints {
-            $0.top.equalTo(operatingHoursSectionTitleLabel.snp.bottom).offset(innerSectionSpacing)
+        openingHoursButton.snp.makeConstraints {
+            $0.top.equalTo(openingHoursSectionTitleLabel.snp.bottom).offset(innerSectionSpacing)
             $0.leading.equalToSuperview()
             $0.bottom.equalToSuperview()
         }
@@ -204,7 +201,7 @@ class SpotListFilterView: GlassmorphismView {
         
         setFooterUI()
         setSpotSectionUI()
-        setOperatingHoursSectionUI()
+        setOpeningHoursSectionUI()
         setPriceSectionUI()
     }
     
@@ -281,8 +278,8 @@ private extension SpotListFilterView {
 
     // MARK: - (Operating hours section)
     
-    func setOperatingHoursSectionUI() {
-        operatingHoursSectionTitleLabel.setLabel(text: StringLiterals.SpotListFilter.operatingHours, style: .t5SB)
+    func setOpeningHoursSectionUI() {
+        openingHoursSectionTitleLabel.setLabel(text: StringLiterals.SpotListFilter.openingHours, style: .t5SB)
     }
     
     // MARK: - (Price section)
@@ -302,9 +299,9 @@ extension SpotListFilterView {
         let tagTexts: [String] = {
             switch spotType {
             case .restaurant:
-                return SpotType.RestaurantFeatureType.allCases.map { return $0.text }
+                return SpotFilterType.RestaurantOptionType.allCases.map { return $0.text }
             case .cafe:
-                return SpotType.CafeFeatureType.allCases.map { return $0.text }
+                return SpotFilterType.CafeOptionType.allCases.map { return $0.text }
             }
         }()
 
@@ -313,8 +310,8 @@ extension SpotListFilterView {
         firstLineSpotTagStackView.switchTagButtons(titles: firstLine)
         secondLineSpotTagStackView.switchTagButtons(titles: secondLine)
         
-        let operatingHours: SpotType.OperatingHours = spotType == .restaurant ? .overMidnight : .overTenPM
-        operatingHoursButton.updateButtonTitle(operatingHours.text)
+        let openingHours: SpotFilterType.OpeningHoursOptionType = spotType == .restaurant ? .overMidnight : .overTenPM
+        openingHoursButton.updateButtonTitle(openingHours.text)
         
         if spotType == .restaurant {
             priceSectionTitleLabel.setLabel(
@@ -326,7 +323,7 @@ extension SpotListFilterView {
     }
 
     func resetAllTagSelection() {
-        [operatingHoursButton, goodPriceButton].forEach { $0.isSelected = false }
+        [openingHoursButton, goodPriceButton].forEach { $0.isSelected = false }
         [firstLineSpotTagStackView,
          secondLineSpotTagStackView].forEach {
             $0.resetTagSelection()

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
@@ -11,7 +11,7 @@ class SpotListFilterViewController: BaseViewController {
     
     // MARK: - Properties
     
-    private let spotListFilterView = SpotListFilterView()
+    private let spotListFilterView: SpotListFilterView
     
     private let viewModel: SpotListViewModel
     
@@ -20,6 +20,7 @@ class SpotListFilterViewController: BaseViewController {
     
     init(viewModel: SpotListViewModel) {
         self.viewModel = viewModel
+        self.spotListFilterView = SpotListFilterView(spotType: viewModel.spotType)
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -176,7 +177,6 @@ private extension SpotListFilterViewController {
         guard let spotType = spotType else { return }
         
         spotListFilterView.do {
-            $0.switchOptionTags(spotType)
             $0.resetAllTagSelection()
         }
     }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
@@ -176,8 +176,7 @@ private extension SpotListFilterViewController {
         guard let spotType = spotType else { return }
         
         spotListFilterView.do {
-            // NOTE: spot tag 바꾸기
-            $0.switchSpotTagStack(spotType)
+            $0.switchOptionTags(spotType)
             $0.resetAllTagSelection()
         }
     }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
@@ -195,6 +195,8 @@ private extension SpotListFilterViewController {
                 applySpotConditionToUI(
                     spotType: spotType,
                     optionList: filterList.optionList)
+            case .openingHours: return // TODO: 수정
+            case .price: return // TODO: 수정
             }
         }
     }
@@ -202,14 +204,14 @@ private extension SpotListFilterViewController {
 }
 
 
-// MARK: - Assisting method
+// MARK: - Helper
 
-extension SpotListFilterViewController {
+private extension SpotListFilterViewController {
     
     // MARK: - UI -> VM
     
     func extractRestaurantFilter() -> SpotFilterModel {
-        let restaurantFeatures = SpotType.RestaurantFeatureType.allCases
+        let restaurantFeatures = SpotFilterType.RestaurantOptionType.allCases
         var restaurantFeatureOptionList: [String] = []
         
         for (i, button) in spotListFilterView.firstLineSpotTagStackView.arrangedSubviews.enumerated() {
@@ -227,7 +229,7 @@ extension SpotListFilterViewController {
         }
         
         let restaurantFilterList = SpotFilterModel(
-            category: SpotType.FilterCategoryType.restaurantFeature,
+            category: SpotFilterType.restaurantFeature,
             optionList: restaurantFeatureOptionList
         )
         
@@ -235,7 +237,7 @@ extension SpotListFilterViewController {
     }
     
     func extractCafeFilter() -> SpotFilterModel {
-        let cafeFeatures = SpotType.CafeFeatureType.allCases
+        let cafeFeatures = SpotFilterType.CafeOptionType.allCases
         var cafeFeatureOptionList: [String] = []
         for (i, button) in spotListFilterView.firstLineSpotTagStackView.arrangedSubviews.enumerated() {
             let tagButton = button as? FilterTagButton ?? UIButton()
@@ -252,7 +254,7 @@ extension SpotListFilterViewController {
         }
         
         let cafeFilterList = SpotFilterModel(
-            category: SpotType.FilterCategoryType.cafeFeature,
+            category: SpotFilterType.cafeFeature,
             optionList: cafeFeatureOptionList
         )
         
@@ -266,9 +268,9 @@ extension SpotListFilterViewController {
         let tagKeys: [String] = {
             switch spotType {
             case .restaurant:
-                return SpotType.RestaurantFeatureType.allCases.map { return $0.serverKey }
+                return SpotFilterType.RestaurantOptionType.allCases.map { return $0.serverKey }
             case .cafe:
-                return SpotType.CafeFeatureType.allCases.map { return $0.serverKey }
+                return SpotFilterType.CafeOptionType.allCases.map { return $0.serverKey }
             }
         }()
         


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #159 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
- **TagStackView 관련 리팩토링**
  1.0에서는 필터뷰 내에서 restaurant <-> cafe 전환 기능이 있었기 때문에, tagStackView의 tag를 교체하는 로직이 필요했습니다.
  하지만 2.0에서는 해당 전환 기능이 제거되었습니다.
  따라서, 불필요하게 메모리 복잡도를 높이던 기존 코드를 제거/리팩토링했습니다.

- **SpotType, SpotFilterType 분리** 했습니다.

- **태그 미선택 시 Footer button 비활성화** 구현했습니다.

- **FilterTagButton** pressed 취소 액션 추가했습니다.


## 📸 스크린샷


https://github.com/user-attachments/assets/63a2e204-5485-445a-b30f-deddfc27e1d8



## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #159
