### PR TITLE
[FEAT] 구글 애즈 적용 (#162)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		746F5BF22DE00CE90081569B /* GlassBorderAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746F5BF12DE00CE90081569B /* GlassBorderAttributes.swift */; };
 		746FF3C02D3D8669001CDAAC /* ACWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */; };
 		74770C192DF1DA97005D4165 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 74770C182DF1DA97005D4165 /* GoogleMobileAds */; };
+		74770C1D2DF36DAB005D4165 /* GoogleAdsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74770C1C2DF36DA2005D4165 /* GoogleAdsType.swift */; };
 		747BB6CE2DCA66F000352874 /* GlassButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747BB6CD2DCA66EB00352874 /* GlassButtonState.swift */; };
 		747F4FBD2D3D9477003DECBF /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747F4FBC2D3D9470003DECBF /* SplashViewController.swift */; };
 		747F4FBF2D3D9D44003DECBF /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747F4FBE2D3D9D40003DECBF /* SplashView.swift */; };
@@ -427,6 +428,7 @@
 		746F5BEF2DE0097B0081569B /* ACToastType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACToastType.swift; sourceTree = "<group>"; };
 		746F5BF12DE00CE90081569B /* GlassBorderAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassBorderAttributes.swift; sourceTree = "<group>"; };
 		746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACWebViewController.swift; sourceTree = "<group>"; };
+		74770C1C2DF36DA2005D4165 /* GoogleAdsType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsType.swift; sourceTree = "<group>"; };
 		747BB6CD2DCA66EB00352874 /* GlassButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassButtonState.swift; sourceTree = "<group>"; };
 		747F4FBC2D3D9470003DECBF /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		747F4FBE2D3D9D40003DECBF /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
@@ -1273,6 +1275,7 @@
 		748D6F7B2D2BCCFF007690B4 /* Enums */ = {
 			isa = PBXGroup;
 			children = (
+				74770C1C2DF36DA2005D4165 /* GoogleAdsType.swift */,
 				747BB6CD2DCA66EB00352874 /* GlassButtonState.swift */,
 				743900962DC86966002F91B1 /* GlassButtonType.swift */,
 				743900922DC7544C002F91B1 /* GlassmorphismType.swift */,
@@ -1873,6 +1876,7 @@
 				745B19B22D40240900BDBDA4 /* AuthService.swift in Sources */,
 				748D6F692D2BCA1C007690B4 /* AppDelegate.swift in Sources */,
 				74054ECE2D32549F00D1CDE4 /* ACLocationManager.swift in Sources */,
+				74770C1D2DF36DAB005D4165 /* GoogleAdsType.swift in Sources */,
 				749A01032D3A6E0100CD7A90 /* ACDebouncer.swift in Sources */,
 				7462617F2D3F9F1400A4E84F /* GetSpotDetailResponse.swift in Sources */,
 				15A1471E2D5A7F96003793EE /* LabelBoxWithDeletableButton.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		743900912DC50926002F91B1 /* UIVisualEffectView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743900902DC50918002F91B1 /* UIVisualEffectView+.swift */; };
 		743900932DC75451002F91B1 /* GlassmorphismType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743900922DC7544C002F91B1 /* GlassmorphismType.swift */; };
 		743900972DC8696A002F91B1 /* GlassButtonType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743900962DC86966002F91B1 /* GlassButtonType.swift */; };
+		74403B6D2DEF900B00B7B832 /* SpotListGoogleAdCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74403B6C2DEF900B00B7B832 /* SpotListGoogleAdCollectionViewCell.swift */; };
 		74403B6F2DF1D6DD00B7B832 /* GoogleAdsErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74403B6E2DF1D6D600B7B832 /* GoogleAdsErrorType.swift */; };
 		745000D72D403F0200262CBE /* lodingLottie.json in Resources */ = {isa = PBXBuildFile; fileRef = 745000D62D403F0200262CBE /* lodingLottie.json */; };
 		745000D82D403F0200262CBE /* checkLottie.json in Resources */ = {isa = PBXBuildFile; fileRef = 745000D52D403F0200262CBE /* checkLottie.json */; };
@@ -388,6 +389,7 @@
 		743900902DC50918002F91B1 /* UIVisualEffectView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIVisualEffectView+.swift"; sourceTree = "<group>"; };
 		743900922DC7544C002F91B1 /* GlassmorphismType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassmorphismType.swift; sourceTree = "<group>"; };
 		743900962DC86966002F91B1 /* GlassButtonType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassButtonType.swift; sourceTree = "<group>"; };
+		74403B6C2DEF900B00B7B832 /* SpotListGoogleAdCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListGoogleAdCollectionViewCell.swift; sourceTree = "<group>"; };
 		74403B6E2DF1D6D600B7B832 /* GoogleAdsErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsErrorType.swift; sourceTree = "<group>"; };
 		745000D52D403F0200262CBE /* checkLottie.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = checkLottie.json; sourceTree = "<group>"; };
 		745000D62D403F0200262CBE /* lodingLottie.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = lodingLottie.json; sourceTree = "<group>"; };
@@ -603,6 +605,7 @@
 		1547A6ED2D33850600E96616 /* Cell */ = {
 			isa = PBXGroup;
 			children = (
+				74403B6C2DEF900B00B7B832 /* SpotListGoogleAdCollectionViewCell.swift */,
 				1547A6EE2D33854B00E96616 /* SpotListCollectionViewCell.swift */,
 				15A246192DE7A9E500469272 /* NoMatchingSpotListCollectionViewCell.swift */,
 				15A3F6AB2D37AB7B00577E16 /* SpotListCollectionViewHeader.swift */,
@@ -1975,6 +1978,7 @@
 				745862702DDBC3CD0075A854 /* ACAlertActionType.swift in Sources */,
 				748D6F7E2D2BCD72007690B4 /* StringLiterals.swift in Sources */,
 				747F4FBD2D3D9477003DECBF /* SplashViewController.swift in Sources */,
+				74403B6D2DEF900B00B7B832 /* SpotListGoogleAdCollectionViewCell.swift in Sources */,
 				15CD25822D40364400320006 /* LoginModalViewController.swift in Sources */,
 				151AB6CB2DD3ED3F00D01DE8 /* MenuCollectionViewCell.swift in Sources */,
 				745ECBA12D615B9F005129B0 /* AlbumTableViewCell.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		74BF92172D393B4A00B923E3 /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BF92162D393B4700B923E3 /* Int+.swift */; };
 		74BF92192D395FE800B923E3 /* ACToastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BF92182D395FE400B923E3 /* ACToastController.swift */; };
 		74BF92272D39957600B923E3 /* StickyHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BF92262D39956F00B923E3 /* StickyHeaderView.swift */; };
+		74C1934A2DEF87E1005FB3C7 /* GoogleAdsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C193492DEF87E1005FB3C7 /* GoogleAdsManager.swift */; };
 		74C914D12D64DBBB00BC13E1 /* ImageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C914D02D64DBAF00BC13E1 /* ImageType.swift */; };
 		74C914D32D64E01C00BC13E1 /* PutImageToPresignedURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C914D22D64E01000BC13E1 /* PutImageToPresignedURLRequest.swift */; };
 		74CDCE562D310B1600E3A21A /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74CDCE552D310B1300E3A21A /* String+.swift */; };
@@ -490,6 +491,7 @@
 		74BF92162D393B4700B923E3 /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
 		74BF92182D395FE400B923E3 /* ACToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACToastController.swift; sourceTree = "<group>"; };
 		74BF92262D39956F00B923E3 /* StickyHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickyHeaderView.swift; sourceTree = "<group>"; };
+		74C193492DEF87E1005FB3C7 /* GoogleAdsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsManager.swift; sourceTree = "<group>"; };
 		74C914D02D64DBAF00BC13E1 /* ImageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageType.swift; sourceTree = "<group>"; };
 		74C914D22D64E01000BC13E1 /* PutImageToPresignedURLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PutImageToPresignedURLRequest.swift; sourceTree = "<group>"; };
 		74CDCE552D310B1300E3A21A /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
@@ -1046,6 +1048,7 @@
 		7462D0232D4262EA00580464 /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				74C193492DEF87E1005FB3C7 /* GoogleAdsManager.swift */,
 				749234992D687B0D0025F700 /* AmplitudeManager.swift */,
 				741429662D5D550400B69528 /* AppVersionManager.swift */,
 				7462D0242D4262EF00580464 /* AuthManager.swift */,
@@ -1884,6 +1887,7 @@
 				7462617F2D3F9F1400A4E84F /* GetSpotDetailResponse.swift in Sources */,
 				15A1471E2D5A7F96003793EE /* LabelBoxWithDeletableButton.swift in Sources */,
 				743900972DC8696A002F91B1 /* GlassButtonType.swift in Sources */,
+				74C1934A2DEF87E1005FB3C7 /* GoogleAdsManager.swift in Sources */,
 				745C7E0D2D35A04A0074DBDB /* SearchKeywordCollectionViewCell.swift in Sources */,
 				748D6FA62D2C3F44007690B4 /* BaseView.swift in Sources */,
 				15CD25702D3F86E700320006 /* CustomRefreshControl.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		746F5BF02DE009820081569B /* ACToastType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746F5BEF2DE0097B0081569B /* ACToastType.swift */; };
 		746F5BF22DE00CE90081569B /* GlassBorderAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746F5BF12DE00CE90081569B /* GlassBorderAttributes.swift */; };
 		746FF3C02D3D8669001CDAAC /* ACWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */; };
+		74770C192DF1DA97005D4165 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 74770C182DF1DA97005D4165 /* GoogleMobileAds */; };
 		747BB6CE2DCA66F000352874 /* GlassButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747BB6CD2DCA66EB00352874 /* GlassButtonState.swift */; };
 		747F4FBD2D3D9477003DECBF /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747F4FBC2D3D9470003DECBF /* SplashViewController.swift */; };
 		747F4FBF2D3D9D44003DECBF /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747F4FBE2D3D9D40003DECBF /* SplashView.swift */; };
@@ -531,6 +532,7 @@
 				74B25C252D2FD30A008BDCB7 /* Lottie in Frameworks */,
 				748D6F4A2D2BC52B007690B4 /* Kingfisher in Frameworks */,
 				746AA0342DAD0EE300E28B66 /* FirebaseCrashlytics in Frameworks */,
+				74770C192DF1DA97005D4165 /* GoogleMobileAds in Frameworks */,
 				748D6F412D2BC482007690B4 /* Moya in Frameworks */,
 				748D6F4F2D2BC76C007690B4 /* GoogleSignInSwift in Frameworks */,
 				748D6F472D2BC519007690B4 /* Then in Frameworks */,
@@ -1686,6 +1688,7 @@
 				74B25C242D2FD30A008BDCB7 /* Lottie */,
 				74D831912D6878A5003384C6 /* AmplitudeSwift */,
 				746AA0332DAD0EE300E28B66 /* FirebaseCrashlytics */,
+				74770C182DF1DA97005D4165 /* GoogleMobileAds */,
 			);
 			productName = "ACON-iOS";
 			productReference = 74AB6EB02D2796D30094F873 /* ACON-iOS.app */;
@@ -2397,6 +2400,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 746AA0302DAD0EE300E28B66 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseCrashlytics;
+		};
+		74770C182DF1DA97005D4165 /* GoogleMobileAds */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 74C1934B2DEF8909005FB3C7 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
+			productName = GoogleMobileAds;
 		};
 		748D6F402D2BC482007690B4 /* Moya */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		743900912DC50926002F91B1 /* UIVisualEffectView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743900902DC50918002F91B1 /* UIVisualEffectView+.swift */; };
 		743900932DC75451002F91B1 /* GlassmorphismType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743900922DC7544C002F91B1 /* GlassmorphismType.swift */; };
 		743900972DC8696A002F91B1 /* GlassButtonType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743900962DC86966002F91B1 /* GlassButtonType.swift */; };
+		74403B6F2DF1D6DD00B7B832 /* GoogleAdsErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74403B6E2DF1D6D600B7B832 /* GoogleAdsErrorType.swift */; };
 		745000D72D403F0200262CBE /* lodingLottie.json in Resources */ = {isa = PBXBuildFile; fileRef = 745000D62D403F0200262CBE /* lodingLottie.json */; };
 		745000D82D403F0200262CBE /* checkLottie.json in Resources */ = {isa = PBXBuildFile; fileRef = 745000D52D403F0200262CBE /* checkLottie.json */; };
 		745862702DDBC3CD0075A854 /* ACAlertActionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7458626F2DDBC3C60075A854 /* ACAlertActionType.swift */; };
@@ -386,6 +387,7 @@
 		743900902DC50918002F91B1 /* UIVisualEffectView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIVisualEffectView+.swift"; sourceTree = "<group>"; };
 		743900922DC7544C002F91B1 /* GlassmorphismType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassmorphismType.swift; sourceTree = "<group>"; };
 		743900962DC86966002F91B1 /* GlassButtonType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassButtonType.swift; sourceTree = "<group>"; };
+		74403B6E2DF1D6D600B7B832 /* GoogleAdsErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsErrorType.swift; sourceTree = "<group>"; };
 		745000D52D403F0200262CBE /* checkLottie.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = checkLottie.json; sourceTree = "<group>"; };
 		745000D62D403F0200262CBE /* lodingLottie.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = lodingLottie.json; sourceTree = "<group>"; };
 		7458626F2DDBC3C60075A854 /* ACAlertActionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACAlertActionType.swift; sourceTree = "<group>"; };
@@ -1276,6 +1278,7 @@
 			isa = PBXGroup;
 			children = (
 				74770C1C2DF36DA2005D4165 /* GoogleAdsType.swift */,
+				74403B6E2DF1D6D600B7B832 /* GoogleAdsErrorType.swift */,
 				747BB6CD2DCA66EB00352874 /* GlassButtonState.swift */,
 				743900962DC86966002F91B1 /* GlassButtonType.swift */,
 				743900922DC7544C002F91B1 /* GlassmorphismType.swift */,
@@ -1915,6 +1918,7 @@
 				15A3F7A32D38C7FF00577E16 /* SpotFilterTagStackView.swift in Sources */,
 				1547A6EB2D337F4100E96616 /* SpotListView.swift in Sources */,
 				1547A6EF2D33854B00E96616 /* SpotListCollectionViewCell.swift in Sources */,
+				74403B6F2DF1D6DD00B7B832 /* GoogleAdsErrorType.swift in Sources */,
 				15CD25782D3FE31400320006 /* PostSpotListRequest.swift in Sources */,
 				7462617B2D3EB06100A4E84F /* UploadService.swift in Sources */,
 				4C6B2F332D65A15D0089BCB6 /* WithdrawalTargetType.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		746F5BF22DE00CE90081569B /* GlassBorderAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746F5BF12DE00CE90081569B /* GlassBorderAttributes.swift */; };
 		746FF3C02D3D8669001CDAAC /* ACWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */; };
 		74770C192DF1DA97005D4165 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 74770C182DF1DA97005D4165 /* GoogleMobileAds */; };
+		74770C1B2DF35848005D4165 /* ProfileGoogleAdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74770C1A2DF35848005D4165 /* ProfileGoogleAdView.swift */; };
 		74770C1D2DF36DAB005D4165 /* GoogleAdsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74770C1C2DF36DA2005D4165 /* GoogleAdsType.swift */; };
 		747BB6CE2DCA66F000352874 /* GlassButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747BB6CD2DCA66EB00352874 /* GlassButtonState.swift */; };
 		747F4FBD2D3D9477003DECBF /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747F4FBC2D3D9470003DECBF /* SplashViewController.swift */; };
@@ -433,6 +434,7 @@
 		746F5BEF2DE0097B0081569B /* ACToastType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACToastType.swift; sourceTree = "<group>"; };
 		746F5BF12DE00CE90081569B /* GlassBorderAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassBorderAttributes.swift; sourceTree = "<group>"; };
 		746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACWebViewController.swift; sourceTree = "<group>"; };
+		74770C1A2DF35848005D4165 /* ProfileGoogleAdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileGoogleAdView.swift; sourceTree = "<group>"; };
 		74770C1C2DF36DA2005D4165 /* GoogleAdsType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsType.swift; sourceTree = "<group>"; };
 		747BB6CD2DCA66EB00352874 /* GlassButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassButtonState.swift; sourceTree = "<group>"; };
 		747F4FBC2D3D9470003DECBF /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
@@ -578,6 +580,7 @@
 				15A48BFD2D57546A003C2421 /* ProfileImageEditButton.swift */,
 				15CF62BC2D575EC00000A10F /* ProfileEditValidMessageView.swift */,
 				15A1471D2D5A7F96003793EE /* LabelBoxWithDeletableButton.swift */,
+				74770C1A2DF35848005D4165 /* ProfileGoogleAdView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -2028,6 +2031,7 @@
 				7436352C2DEE2C70009B0035 /* OnboardingFlowType.swift in Sources */,
 				741E68A22D3D5FA200DF99EF /* ACService.swift in Sources */,
 				156AA7242D6504F1005B8DCE /* GetVerifiedAreaListResponse.swift in Sources */,
+				74770C1B2DF35848005D4165 /* ProfileGoogleAdView.swift in Sources */,
 				74E38D342D69B46F009449D4 /* LocationUtils.swift in Sources */,
 				1558BADB2D31AAF900ECDEF8 /* ACTabBarItemType.swift in Sources */,
 				D6978F542D37B29100523A25 /* OnboardingService.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -1724,6 +1724,7 @@
 				74B25C232D2FD30A008BDCB7 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				74D831902D6878A5003384C6 /* XCRemoteSwiftPackageReference "Amplitude-Swift" */,
 				746AA0302DAD0EE300E28B66 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				74C1934B2DEF8909005FB3C7 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 74AB6EB12D2796D30094F873 /* Products */;
@@ -2371,6 +2372,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 4.5.1;
+			};
+		};
+		74C1934B2DEF8909005FB3C7 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/googleads/swift-package-manager-google-mobile-ads.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.5.0;
 			};
 		};
 		74D831902D6878A5003384C6 /* XCRemoteSwiftPackageReference "Amplitude-Swift" */ = {

--- a/ACON-iOS/ACON-iOS/Application/AppDelegate.swift
+++ b/ACON-iOS/ACON-iOS/Application/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
         
         /// 구글 애즈 초기화
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             GoogleAdsManager.shared.initialize()
         }
         

--- a/ACON-iOS/ACON-iOS/Application/AppDelegate.swift
+++ b/ACON-iOS/ACON-iOS/Application/AppDelegate.swift
@@ -22,6 +22,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
         
+        /// 구글 애즈 초기화
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            GoogleAdsManager.shared.initialize()
+        }
+        
         return true
     }
 

--- a/ACON-iOS/ACON-iOS/Global/Service/GoogleAdsManager.swift
+++ b/ACON-iOS/ACON-iOS/Global/Service/GoogleAdsManager.swift
@@ -1,0 +1,207 @@
+//
+//  GoogleAdsManager.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 6/4/25.
+//
+
+import Foundation
+
+import GoogleMobileAds
+import Network
+
+final class GoogleAdsManager: NSObject {
+    
+    // MARK: - Properties
+    
+    static let shared = GoogleAdsManager()
+    
+    private var adLoader: AdLoader?
+    
+    private var cachedAd: [GoogleAdsType: NativeAd] = [:]
+    
+    private var loadCompletion: ((NativeAd?, Error?) -> Void)?
+    
+    private var isLoading = false
+    
+    private var isNetworkConnected = false
+    
+    var needsAdReloadOnNetworkRecovery = false
+    
+    private var periodicNetworkCheckTimer: Timer?
+    
+
+    // MARK: - Internal Methods
+    
+    func initialize() {
+        MobileAds.shared.start(completionHandler: nil)
+        
+        periodicNetworkCheck()
+        preloadNativeAd(.imageOnly)
+        preloadNativeAd(.both)
+    }
+    
+    func getNativeAd(_ adType: GoogleAdsType) -> NativeAd? {
+        guard let ad = cachedAd[adType] else {
+            print("🥐 캐시된 광고 없음 - 즉시 로드 시작")
+            if !isLoading {
+                preloadNativeAd(adType)
+            }
+            return nil
+        }
+        
+        cachedAd[adType] = nil
+        print("🥐 캐시된 광고 반환 - 다음 광고 로드 시작")
+        preloadNativeAd(adType)
+        return ad
+    }
+    
+    func preloadNativeAd(_ adType: GoogleAdsType) {
+        guard cachedAd[adType] == nil && !isLoading else { return }
+
+        self.loadNativeAd(adType) { [weak self] ad, error in
+            if let ad = ad {
+                self?.cachedAd[adType] = ad
+            } else {
+                self?.handleAdLoadError(error)
+            }
+        }
+    }
+    
+    
+    // MARK: - Private Methods
+    
+    private func loadNativeAd(_ adType: GoogleAdsType,
+                              completion: @escaping ((NativeAd?, Error?) -> Void)) {
+        guard !isLoading else {
+            completion(nil, GoogleAdsManagerError.alreadyLoading)
+            return
+        }
+        
+        isLoading = true
+        loadCompletion = completion
+        
+        DispatchQueue.main.async {
+            guard let windowScene = UIApplication.shared.connectedScenes
+                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+                  let rootViewController = windowScene.windows.first?.rootViewController else {
+                completion(nil, GoogleAdsManagerError.noWindowScene)
+                return
+            }
+            
+            DispatchQueue.global().async {
+                let adUnitID = adType == .both ? Config.GADAdUnitID : Config.GADAdUnitIDImageOnly
+                let request = Request()
+                
+                let options = NativeAdImageAdLoaderOptions().then {
+                    $0.isImageLoadingDisabled = false
+                    $0.shouldRequestMultipleImages = false
+                }
+                
+                self.adLoader = AdLoader(
+                    adUnitID: adUnitID,
+                    rootViewController: rootViewController,
+                    adTypes: [.native],
+                    options: [options]
+                ).then {
+                    $0.delegate = self
+                }
+                
+                self.adLoader?.load(request)
+            }
+        }
+    }
+    
+}
+
+
+// MARK: - AdLoaderDelegate
+
+extension GoogleAdsManager: NativeAdLoaderDelegate {
+    
+    func adLoader(_ adLoader: AdLoader, didReceive nativeAd: NativeAd) {
+        loadCompletion?(nativeAd, nil)
+        loadCompletion = nil
+        isLoading = false
+    }
+    
+    func adLoader(_ adLoader: AdLoader, didFailToReceiveAdWithError error: Error) {
+        loadCompletion?(nil, error)
+        loadCompletion = nil
+        isLoading = false
+    }
+    
+}
+
+
+// MARK: - 네트워크 연결 관련 메소드
+
+extension GoogleAdsManager {
+    
+    // NOTE: 광고 객체 초기화
+    func resetAdState() {
+        cachedAd.removeAll()
+        isLoading = false
+        isNetworkConnected = false
+        needsAdReloadOnNetworkRecovery = false
+    }
+    
+    // NOTE: 3초마다 네트워크 확인
+    // TODO: - 추후 위치 감지 로직에 사용, 혹은 통합 (주기적 체크)
+    func periodicNetworkCheck() {
+        periodicNetworkCheckTimer?.invalidate()
+        periodicNetworkCheckTimer = nil
+        
+        periodicNetworkCheckTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            
+            let monitor = NWPathMonitor()
+            let checkQueue = DispatchQueue(label: "PeriodicNetworkCheck")
+            
+            monitor.pathUpdateHandler = { path in
+                let isConnected = path.status == .satisfied
+                let previousState = self.isNetworkConnected
+                self.isNetworkConnected = isConnected
+                
+                if isConnected && !previousState && self.needsAdReloadOnNetworkRecovery {
+                    print("🥐 periodicNetworkCheck - 네트워크 복구 감지")
+                    
+                    DispatchQueue.main.async {
+                        self.needsAdReloadOnNetworkRecovery = false
+                        
+                        self.resetAdState()
+                        self.preloadNativeAd(.imageOnly)
+                        self.preloadNativeAd(.both)
+                    }
+                } else if !isConnected && previousState {
+                    print("🥐 periodicNetworkCheck - 네트워크 끊김 감지")
+                    self.needsAdReloadOnNetworkRecovery = true
+                }
+                monitor.cancel()
+            }
+            monitor.start(queue: checkQueue)
+        }
+        print("🥐 periodicNetworkCheck - 네트워크 확인 시작")
+    }
+    
+}
+
+
+// MARK: - 에러 핸들링
+
+extension GoogleAdsManager {
+    
+    private func handleAdLoadError(_ error: Error?) {
+        guard let adError = error else { return }
+        
+        let adErrorType = GoogleAdsErrorType(from: adError)
+        print("🥐 광고 로드 실패: \(adErrorType.description)")
+
+        if case .networkError = adErrorType {
+            resetAdState()
+            needsAdReloadOnNetworkRecovery = true
+            return
+        }
+    }
+    
+}

--- a/ACON-iOS/ACON-iOS/Global/Settings/Config/Config.swift
+++ b/ACON-iOS/ACON-iOS/Global/Settings/Config/Config.swift
@@ -29,6 +29,8 @@ enum Config {
             
             static let GADApplicationIdentifier = "GADApplicationIdentifier"
             
+            static let GADAdUnitIDImageOnly = "GAD_AD_UNIT_ID_IMAGE_ONLY"
+            
             static let GADAdUnitID = "GAD_AD_UNIT_ID"
             
         }
@@ -109,5 +111,13 @@ extension Config {
         }
         return key
     }()
+    
+    static let GADAdUnitIDImageOnly: String = {
+        guard let key = Config.infoDictionary[Keys.Plist.GADAdUnitIDImageOnly] as? String else {
+            fatalError("GADAddUnitIDImageOnly is not set in plist for this configuration")
+        }
+        return key
+    }()
+    
     
 }

--- a/ACON-iOS/ACON-iOS/Global/Settings/Config/Config.swift
+++ b/ACON-iOS/ACON-iOS/Global/Settings/Config/Config.swift
@@ -27,6 +27,10 @@ enum Config {
             
             static let nmfCustomStyleID = "NMFCustomStyleID"
             
+            static let GADApplicationIdentifier = "GADApplicationIdentifier"
+            
+            static let GADAdUnitID = "GAD_AD_UNIT_ID"
+            
         }
         
     }
@@ -88,6 +92,20 @@ extension Config {
     static let nmfCustomStyleID: String = {
         guard let key = Config.infoDictionary[Keys.Plist.nmfCustomStyleID] as? String else {
             fatalError("nmfCustomStyleID is not set in plist for this configuration")
+        }
+        return key
+    }()
+    
+    static let GADApplicationIdentifier: String = {
+        guard let key = Config.infoDictionary[Keys.Plist.GADApplicationIdentifier] as? String else {
+            fatalError("GADApplicationIdentifier is not set in plist for this configuration")
+        }
+        return key
+    }()
+    
+    static let GADAdUnitID: String = {
+        guard let key = Config.infoDictionary[Keys.Plist.GADAdUnitID] as? String else {
+            fatalError("GADAddUnitID is not set in plist for this configuration")
         }
         return key
     }()

--- a/ACON-iOS/ACON-iOS/Global/Settings/Info.plist
+++ b/ACON-iOS/ACON-iOS/Global/Settings/Info.plist
@@ -61,6 +61,8 @@
 	<string>${GAD_APPLICATION_IDENTIFIER}</string>
 	<key>GAD_AD_UNIT_ID</key>
 	<string>${GAD_AD_UNIT_ID}</string>
+	<key>GAD_AD_UNIT_ID_IMAGE_ONLY</key>
+	<string>${GAD_AD_UNIT_ID_IMAGE_ONLY}</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/ACON-iOS/ACON-iOS/Global/Settings/Info.plist
+++ b/ACON-iOS/ACON-iOS/Global/Settings/Info.plist
@@ -57,6 +57,10 @@
 	<string>${NMF_NCP_KEY_ID}</string>
 	<key>NMFCustomStyleID</key>
 	<string>${NMF_CUSTOM_STYLE_ID}</string>
+	<key>GADApplicationIdentifier</key>
+	<string>${GAD_APPLICATION_IDENTIFIER}</string>
+	<key>GAD_AD_UNIT_ID</key>
+	<string>${GAD_AD_UNIT_ID}</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/ACON-iOS/ACON-iOS/Global/UIComponents/GlassmorphismView.swift
+++ b/ACON-iOS/ACON-iOS/Global/UIComponents/GlassmorphismView.swift
@@ -92,7 +92,9 @@ extension GlassmorphismView {
 extension GlassmorphismView {
     
     func setGradient(topColor: UIColor = .gray900.withAlphaComponent(1),
-                     bottomColor: UIColor = .gray900.withAlphaComponent(0.1)) {
+                     bottomColor: UIColor = .gray900.withAlphaComponent(0.1),
+                     startPoint: CGPoint = CGPoint(x: 0.5, y: 0.0),
+                     endPoint: CGPoint = CGPoint(x: 0.5, y: 1.0)) {
         layer.sublayers?.filter { $0 is CAGradientLayer }.forEach { $0.removeFromSuperlayer()
         }
         
@@ -100,9 +102,11 @@ extension GlassmorphismView {
         gradient.do {
             $0.frame = bounds
             $0.colors = [topColor.cgColor, bottomColor.cgColor]
-            $0.startPoint = CGPoint(x: 0.5, y: 0.0)
-            $0.endPoint = CGPoint(x: 0.5, y: 1.0)
+            $0.startPoint = startPoint
+            $0.endPoint = endPoint
         }
+        // TODO: - 그라 밑 글모? 글모 밑 그라? -> 디자인에게 물어보기
+//        blurEffectView.contentView.layer.insertSublayer(gradient, at: 0)
         layer.insertSublayer(gradient, at: 0)
     }
     

--- a/ACON-iOS/ACON-iOS/Global/Utils/Enums/GlassButtonType.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/Enums/GlassButtonType.swift
@@ -21,6 +21,8 @@ enum GlassButtonType {
     
     case full_19_b1R
     
+    case full_14_b1R
+    
     case both_20_labelAction_t4R
     
     var cornerRadius: CGFloat {
@@ -31,6 +33,8 @@ enum GlassButtonType {
             return 19
         case .both_20_labelAction_t4R:
             return 20
+        case .full_14_b1R:
+            return 14
         case .full_12_t4SB, .line_12_b1SB:
             return 12
         case .full_10_b1SB:
@@ -44,7 +48,7 @@ enum GlassButtonType {
             return .init(top: 15, leading: 15, bottom: 15, trailing: 15)
         case .line_12_b1SB, .full_22_b1SB, .line_22_b1SB:
             return .init(top: 12, leading: 12, bottom: 12, trailing: 12)
-        case .full_19_b1R:
+        case .full_19_b1R, .full_14_b1R:
             return .init(top: 9, leading: 12, bottom: 9, trailing: 12)
         case .full_10_b1SB:
             return .init(top: 8, leading: 8, bottom: 8, trailing: 8)
@@ -61,7 +65,7 @@ enum GlassButtonType {
             return .t4R
         case .full_12_t4SB:
             return .t4SB
-        case .full_19_b1R:
+        case .full_19_b1R, .full_14_b1R:
             return .b1R
         }
     }

--- a/ACON-iOS/ACON-iOS/Global/Utils/Enums/GoogleAdsErrorType.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/Enums/GoogleAdsErrorType.swift
@@ -1,0 +1,104 @@
+//
+//  GoogleAdsErrorType.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 6/5/25.
+//
+
+import UIKit
+
+import GoogleMobileAds
+
+enum GoogleAdsErrorType {
+    
+    case networkError
+    
+    case noAdToShow
+    
+    case managerError(GoogleAdsManagerError)
+    
+    case unknownError(String)
+    
+    init(from error: Error) {
+        let nsError = error as NSError
+        
+        switch nsError.domain {
+        case NSURLErrorDomain:
+            // NOTE: - 네트워크 에러
+            if nsError.code == NSURLErrorNotConnectedToInternet {
+                self = .networkError
+            } else {
+                self = .unknownError("Network: \(nsError.localizedDescription)")
+            }
+            
+        case "com.google.admob":
+            // NOTE: - 구글 애드몹 에러 (구글에서 내려주는 에러)
+            switch nsError.code {
+            case 1:
+                self = .noAdToShow
+            case 2:
+                self = .networkError
+            default:
+                self = .unknownError("AdMob(\(nsError.code)): \(nsError.localizedDescription)")
+            }
+        
+        case "GoogleAdsManager":
+            // NOTE: - GoogleAdsManager 에러 (자체 에러)
+            switch nsError.code {
+            case 1:
+                self = .managerError(.alreadyLoading)
+            case 2:
+                self = .managerError(.noWindowScene)
+            default:
+                self = .unknownError("Manager(\(nsError.code)): \(nsError.localizedDescription)")
+            }
+            
+        default:
+            self = .unknownError("Unknown(\(nsError.domain)): \(nsError.localizedDescription)")
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .networkError:
+            return "네트워크 에러"
+        case .noAdToShow:
+            return "표시할 광고 없음 (제한 다 씀)"
+        case .managerError(let managerError):
+            return managerError.description
+        case .unknownError(let message):
+            return "unknownError - \(message)"
+        }
+    }
+    
+}
+
+
+// MARK: - GoogleAdsManagerErr
+
+enum GoogleAdsManagerError: Error {
+    
+    case alreadyLoading // NOTE: - 이미 광고 로드 중
+    case noWindowScene  // NORE: - Window Scene 없음
+    
+    var nsError: NSError {
+        switch self {
+        case .alreadyLoading:
+            return NSError(domain: "GoogleAdsManager", code: 1,
+                         userInfo: [NSLocalizedDescriptionKey: "Already loading"])
+        case .noWindowScene:
+            return NSError(domain: "GoogleAdsManager", code: 2,
+                         userInfo: [NSLocalizedDescriptionKey: "No active window scene found"])
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .alreadyLoading:
+            return "로드 중"
+        case .noWindowScene:
+            return "Window Scene 없음"
+        }
+    }
+    
+}

--- a/ACON-iOS/ACON-iOS/Global/Utils/Enums/GoogleAdsType.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/Enums/GoogleAdsType.swift
@@ -1,0 +1,14 @@
+//
+//  GoogleAdsType.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 6/7/25.
+//
+
+enum GoogleAdsType: String {
+    
+    case imageOnly
+    
+    case both
+    
+}

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/Component/ProfileGoogleAdView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/Component/ProfileGoogleAdView.swift
@@ -1,0 +1,187 @@
+//
+//  ProfileGoogleAdView.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 6/7/25.
+//
+
+import UIKit
+
+import GoogleMobileAds
+
+class ProfileGoogleAdView: BaseView {
+    
+    // MARK: - UI Properties
+    
+    private let glassmorphismView: GlassmorphismView = GlassmorphismView(.buttonGlassDefault)
+    
+    private let nativeAdView = NativeAdView()
+    
+    private let adButton = ACButton(style: GlassButton(glassmorphismType: .buttonGlassDefault, buttonType: .full_14_b1R), title: "광고")
+    
+    private let headlineLabel = UILabel()
+    
+    private let bodyLabel = UILabel()
+    
+    private let iconImageView = UIImageView()
+    
+    private let mediaView = MediaView()
+
+    private let callToActionButton = ACButton(style: GlassButton(glassmorphismType: .buttonGlassDefault, buttonType: .full_10_b1SB))
+    
+    private let skeletonView = SkeletonView()
+    
+    
+    // MARK: - Lifecycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setNativeAdView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setHierarchy() {
+        self.addSubviews(glassmorphismView, nativeAdView, skeletonView)
+
+        nativeAdView.addSubviews(mediaView,
+                                 adButton,
+                                 headlineLabel)
+    }
+    
+    override func setLayout() {
+        super.setLayout()
+
+        glassmorphismView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        nativeAdView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        skeletonView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        adButton.snp.makeConstraints {
+            $0.top.trailing.equalToSuperview().inset(ScreenUtils.horizontalInset)
+            $0.width.equalTo(48)
+            $0.height.equalTo(28)
+        }
+        
+        headlineLabel.snp.makeConstraints {
+            $0.top.leading.equalTo(ScreenUtils.horizontalInset)
+            $0.width.equalTo(150)
+            $0.height.equalTo(24)
+        }
+
+        mediaView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    override func setStyle() {
+        self.do {
+            $0.layer.cornerRadius = 12
+            $0.layer.shadowOffset = CGSize(width: 0, height: 2)
+            $0.layer.shadowRadius = 4
+            $0.layer.shadowOpacity = 0.1
+            $0.backgroundColor = .clear
+        }
+        
+        skeletonView.isHidden = true
+        
+        mediaView.do {
+            $0.layer.cornerRadius = 8
+            $0.clipsToBounds = true
+        }
+
+        adButton.do {
+            $0.updateGlassButtonState(state: .default)
+            $0.isUserInteractionEnabled = false
+        }
+        
+        glassmorphismView.do {
+            $0.setGradient(bottomColor: .gray900.withAlphaComponent(0),
+                           endPoint: CGPoint(x: 0.5, y: 0.5))
+        }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        glassmorphismView.layer.cornerRadius = 12
+        glassmorphismView.clipsToBounds = true
+        
+        glassmorphismView.refreshBlurEffect()
+        glassmorphismView.setGradient(bottomColor: .gray900.withAlphaComponent(0),
+                                       endPoint: CGPoint(x: 0.5, y: 0.5))
+        adButton.updateGlassButtonState(state: .default)
+    }
+}
+
+
+// MARK: - Configure
+
+extension ProfileGoogleAdView {
+    
+    private func setNativeAdView() {
+        nativeAdView.do {
+            $0.headlineView = headlineLabel
+            $0.mediaView = mediaView
+        }
+    }
+    
+    func configure(with nativeAd: NativeAd) {
+        nativeAdView.nativeAd = nil
+        nativeAd.delegate = self
+        
+        nativeAdView.isHidden = false
+        skeletonView.isHidden = true
+        
+        if let headline = nativeAd.headline {
+            headlineLabel.setLabel(text: headline, style: .t4SB)
+            headlineLabel.isHidden = false
+        } else {
+            headlineLabel.isHidden = true
+        }
+ 
+        let mediaContent = nativeAd.mediaContent
+        mediaView.mediaContent = mediaContent
+        
+        nativeAdView.nativeAd = nativeAd
+    }
+    
+}
+
+
+// MARK: - Empty Cell
+
+extension ProfileGoogleAdView {
+    
+    func showSkeleton() {
+        nativeAdView.isHidden = true
+        // TODO: - 스켈레톤 애니메이션 적용
+    }
+    
+}
+
+
+// MARK: - NativeAdDelegate
+
+extension ProfileGoogleAdView: NativeAdDelegate {
+    
+    // TODO: - 광고 관련 기록 -> 추후 엠플 사용?
+    func nativeAdDidRecordClick(_ nativeAd: NativeAd) {
+        print("광고 클릭됨")
+    }
+    
+    func nativeAdDidRecordImpression(_ nativeAd: NativeAd) {
+        print("광고 인식됨")
+    }
+    
+}

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/Component/ProfileGoogleAdView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/Component/ProfileGoogleAdView.swift
@@ -75,7 +75,7 @@ class ProfileGoogleAdView: BaseView {
         
         headlineLabel.snp.makeConstraints {
             $0.top.leading.equalTo(ScreenUtils.horizontalInset)
-            $0.width.equalTo(150)
+            $0.width.equalTo(210)
             $0.height.equalTo(24)
         }
 
@@ -177,11 +177,11 @@ extension ProfileGoogleAdView: NativeAdDelegate {
     
     // TODO: - 광고 관련 기록 -> 추후 엠플 사용?
     func nativeAdDidRecordClick(_ nativeAd: NativeAd) {
-        print("광고 클릭됨")
+        print("Profile 광고 클릭됨")
     }
     
     func nativeAdDidRecordImpression(_ nativeAd: NativeAd) {
-        print("광고 인식됨")
+        print("Profile 광고 인식됨")
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileView.swift
@@ -28,7 +28,9 @@ final class ProfileView: BaseView {
 
     let needLoginButton = UIButton()
     
-
+    let googleAdView = ProfileGoogleAdView()
+    
+    
     // MARK: - UI Setting Methods
 
     override func setStyle() {
@@ -71,7 +73,8 @@ final class ProfileView: BaseView {
             profileImageView,
             nicknameLabel,
             profileEditButton,
-            needLoginButton
+            needLoginButton,
+            googleAdView
         )
     }
 
@@ -98,6 +101,12 @@ final class ProfileView: BaseView {
         needLoginButton.snp.makeConstraints {
             $0.leading.equalTo(nicknameLabel)
             $0.centerY.equalTo(profileImageView)
+        }
+        
+        googleAdView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(423*ScreenUtils.heightRatio)
+            $0.horizontalEdges.equalToSuperview().inset(20*ScreenUtils.widthRatio)
+            $0.height.equalTo(125*ScreenUtils.heightRatio)
         }
     }
 

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
@@ -32,6 +32,13 @@ final class ProfileViewController: BaseNavViewController {
         if AuthManager.shared.hasToken {
             viewModel.getProfile()
         }
+        
+        profileView.googleAdView.layoutSubviews()
+        if let nativeAd = GoogleAdsManager.shared.getNativeAd(.both) {
+            profileView.googleAdView.configure(with: nativeAd)
+        } else {
+            profileView.googleAdView.showSkeleton()
+        }
     }
 
     override func setHierarchy() {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/SpotListGoogleAdCollectionViewCell.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/SpotListGoogleAdCollectionViewCell.swift
@@ -1,0 +1,241 @@
+//
+//  NativeAdCell.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 6/4/25.
+//
+
+import UIKit
+
+import GoogleMobileAds
+
+class SpotListGoogleAdCollectionViewCell: BaseCollectionViewCell {
+    
+    // MARK: - UI Properties
+    
+    private let glassmorphismView: GlassmorphismView = GlassmorphismView(.buttonGlassDefault)
+    
+    private let nativeAdView = NativeAdView()
+    
+    private let adButton = ACButton(style: GlassButton(glassmorphismType: .buttonGlassDefault, buttonType: .full_19_b1R), title: "광고")
+    
+    private let headlineLabel = UILabel()
+    
+    private let bodyLabel = UILabel()
+    
+    private let iconImageView = UIImageView()
+    
+    private let mediaView = MediaView()
+
+    private let callToActionButton = ACButton(style: GlassButton(glassmorphismType: .buttonGlassDefault, buttonType: .full_10_b1SB))
+    
+    private let skeletonView = SkeletonView()
+    
+    
+    // MARK: - Lifecycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setNativeAdView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setHierarchy() {
+        contentView.addSubviews(glassmorphismView, nativeAdView)
+
+        nativeAdView.addSubviews(mediaView,
+                                 adButton,
+                                 headlineLabel,
+                                 bodyLabel,
+                                 iconImageView,
+                                 callToActionButton)
+    }
+    
+    override func setLayout() {
+        super.setLayout()
+        
+        let edge = ScreenUtils.widthRatio * 20
+        
+        glassmorphismView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        nativeAdView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+//        
+//        skeletonView.snp.makeConstraints {
+//            $0.edges.equalToSuperview()
+//        }
+        
+        adButton.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(52*ScreenUtils.heightRatio)
+            $0.leading.equalToSuperview().inset(edge)
+            $0.width.equalTo(48)
+            $0.height.equalTo(38)
+        }
+        
+        iconImageView.snp.makeConstraints {
+            $0.leading.bottom.equalToSuperview().inset(edge)
+            $0.size.equalTo(36)
+        }
+        
+        headlineLabel.snp.makeConstraints {
+            $0.top.leading.equalTo(edge)
+            $0.width.equalTo(210)
+            $0.height.equalTo(24)
+        }
+        
+        bodyLabel.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(76*ScreenUtils.heightRatio)
+            $0.horizontalEdges.equalToSuperview().inset(edge)
+            $0.height.equalTo(40)
+        }
+        
+        mediaView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        callToActionButton.snp.makeConstraints {
+            $0.bottom.trailing.equalToSuperview().inset(edge)
+            $0.width.equalTo(140)
+            $0.height.equalTo(36)
+        }
+    }
+    
+    override func setStyle() {
+        contentView.do {
+            $0.layer.cornerRadius = 12
+            $0.layer.shadowOffset = CGSize(width: 0, height: 2)
+            $0.layer.shadowRadius = 4
+            $0.layer.shadowOpacity = 0.1
+            $0.backgroundColor = .clear
+        }
+        
+        skeletonView.isHidden = true
+        
+        iconImageView.do {
+            $0.contentMode = .scaleAspectFill
+            $0.layer.cornerRadius = 8
+            $0.clipsToBounds = true
+            $0.backgroundColor = .systemGray6
+        }
+        
+        mediaView.do {
+            $0.layer.cornerRadius = 8
+            $0.clipsToBounds = true
+        }
+
+        [adButton, callToActionButton].forEach {
+            $0.do {
+                $0.updateGlassButtonState(state: .default)
+                $0.isUserInteractionEnabled = false
+            }
+        }
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        nativeAdView.nativeAd = nil
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        glassmorphismView.layer.cornerRadius = 12
+        glassmorphismView.clipsToBounds = true
+        
+        glassmorphismView.refreshBlurEffect()
+        adButton.updateGlassButtonState(state: .default)
+        callToActionButton.updateGlassButtonState(state: .default)
+    }
+}
+
+
+// MARK: - Configure
+
+extension SpotListGoogleAdCollectionViewCell {
+    
+    private func setNativeAdView() {
+        nativeAdView.do {
+            $0.headlineView = headlineLabel
+            $0.bodyView = bodyLabel
+            $0.callToActionView = callToActionButton
+            $0.iconView = iconImageView
+            $0.mediaView = mediaView
+        }
+    }
+    
+    func configure(with nativeAd: NativeAd) {
+        nativeAd.delegate = self
+        
+        nativeAdView.isHidden = false
+        skeletonView.isHidden = true
+        
+        if let headline = nativeAd.headline {
+            headlineLabel.setLabel(text: headline, style: .t4SB)
+            headlineLabel.isHidden = false
+        } else {
+            headlineLabel.isHidden = true
+        }
+        
+        if let body = nativeAd.body {
+            bodyLabel.setLabel(text: body, style: .b1R)
+            bodyLabel.isHidden = false
+        } else {
+            bodyLabel.isHidden = true
+        }
+        
+        if let callToAction = nativeAd.callToAction {
+            callToActionButton.updateButtonTitle(callToAction)
+        } else {
+            callToActionButton.updateButtonTitle("자세히 보기")
+        }
+        
+        if let icon = nativeAd.icon {
+            iconImageView.image = icon.image
+            iconImageView.isHidden = false
+        } else {
+            iconImageView.isHidden = true
+        }
+        
+        let mediaContent = nativeAd.mediaContent
+        mediaView.mediaContent = mediaContent
+        
+        nativeAdView.nativeAd = nativeAd
+    }
+    
+}
+
+
+// MARK: - Empty Cell
+
+extension SpotListGoogleAdCollectionViewCell {
+    
+    func showSkeleton() {
+        nativeAdView.isHidden = true
+        // TODO: - 스켈레톤 애니메이션 적용
+    }
+    
+}
+
+
+// MARK: - NativeAdDelegate
+
+extension SpotListGoogleAdCollectionViewCell: NativeAdDelegate {
+    
+    // TODO: - 광고 관련 기록 -> 추후 엠플 사용?
+    func nativeAdDidRecordClick(_ nativeAd: NativeAd) {
+        print("Spotlist 광고 클릭됨")
+    }
+    
+    func nativeAdDidRecordImpression(_ nativeAd: NativeAd) {
+        print("Spotlist 광고 인식됨")
+    }
+    
+}

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -259,6 +259,11 @@ private extension SpotListViewController {
         )
         
         spotListView.collectionView.register(
+            SpotListGoogleAdCollectionViewCell.self,
+            forCellWithReuseIdentifier: SpotListGoogleAdCollectionViewCell.cellIdentifier
+        )
+        
+        spotListView.collectionView.register(
             SpotListCollectionViewHeader.self,
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
             withReuseIdentifier: SpotListCollectionViewHeader.identifier
@@ -298,12 +303,23 @@ extension SpotListViewController: UICollectionViewDataSource {
 
         switch spotList.transportMode {
         case .walking:
-            return dequeueAndConfigureCell(
-                collectionView: collectionView,
-                cellType: SpotListCollectionViewCell.self,
-                at: indexPath,
-                with: spotList
-            )
+            if indexPath.item % 5 == 0 && indexPath.item > 0 {
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SpotListGoogleAdCollectionViewCell.cellIdentifier, for: indexPath) as? SpotListGoogleAdCollectionViewCell else {
+                    return UICollectionViewCell() }
+                if let nativeAd = GoogleAdsManager.shared.getNativeAd(.imageOnly) {
+                    cell.configure(with: nativeAd)
+                } else {
+                    cell.showSkeleton()
+                }
+                return cell
+            } else {
+                return dequeueAndConfigureCell(
+                    collectionView: collectionView,
+                    cellType: SpotListCollectionViewCell.self,
+                    at: indexPath,
+                    with: spotList
+                )
+            }
         case .biking:
             return dequeueAndConfigureCell(
                 collectionView: collectionView,


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #162

## 🥔 **작업 내용**
구글 애즈를 적용했습니다


## 🚨 참고 사항
<!-- 참고사항을 적어주세요. -->

### Shared.xcconfig 변경되었습니다! 슬랙에 첨부해둘게요

광고 타입(GoogleAdsType)은 Spotlist에 적용되는 .imageOnly (이미지만) 와 Profile에 적용되는 .both (이미지, 영상 모두)이 있습니다.
각각 동시 로딩 및 관리가 가능하도록 GoogleAdsManager에서 관련 프로퍼티들을 GoogleAdsType을 key로 가지는 딕셔너리로 제작했습니다.

광고가 로드되지 않은 경우 스켈레톤 뷰를 띄웁니다. (추후 완성되면 적용 예정)

광고는 타입별로 하나씩만 미리 캐싱해두고 있습니다.
이 때문에 한 번 광고를 본 직후 다음 광고를 보려 하면 (시뮬 영상 후반의 홈-프로필 빠르게 왔다갔다) 로드가 안 된 경우가 나오는데, 정말 빠르게 이동해야 나오는 케이스라 드물 것이라 판단하였고, 광고가 로드되지 않는 게 사용성에 큰 저하를 끼치지 않는다고 생각해서 다음과 같이 구현했습니다. 여러 개 캐싱 시 해당 문제가 덜 발생하겠지만, 광고를 여러 개 캐싱 시 메모리 문제가 있을 수 있으며, 캐싱 후 사용 안 할 광고에 메모리 낭비를 하고 싶지 않았습니다! 또한 한 번에 하나만 보여주는 앱 특성상 굳이 여러 개 캐싱할 필요는 없다고 판단했습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰 16 Pro|<img src = "https://github.com/user-attachments/assets/4c69148a-775e-4729-9e73-9e507a38a5e2" width ="250">|


## 💥 To be sure
- [ ] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #162
