### PR TITLE
[CHORE] 프로필 QA 반영 및 광고 로직 개선 (#181)

### DIFF
--- a/ACON-iOS/ACON-iOS/Global/Utils/Enums/GoogleAdsType.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/Enums/GoogleAdsType.swift
@@ -5,7 +5,7 @@
 //  Created by 이수민 on 6/7/25.
 //
 
-enum GoogleAdsType: String {
+enum GoogleAdsType: String, CaseIterable, Hashable {
     
     case imageOnly
     

--- a/ACON-iOS/ACON-iOS/Presentation/Album/View/Cell/PhotoCollectionViewCell.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Album/View/Cell/PhotoCollectionViewCell.swift
@@ -22,8 +22,7 @@ final class PhotoCollectionViewCell: BaseCollectionViewCell {
     
     override var isSelected: Bool {
         didSet {
-            whiteView.alpha = isSelected ? 0.3 : 0
-            dimView.alpha = isSelected ? 0.3 : 0
+            dimView.alpha = isSelected ? 1 : 0
         }
     }
     
@@ -32,15 +31,11 @@ final class PhotoCollectionViewCell: BaseCollectionViewCell {
     override func setHierarchy() {
         super.setHierarchy()
         
-        self.addSubviews(photoImageView, whiteView, dimView)
+        self.addSubviews(photoImageView, dimView)
     }
     
     override func setLayout() {
         super.setLayout()
-        
-        whiteView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
         
         dimView.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -57,12 +52,10 @@ final class PhotoCollectionViewCell: BaseCollectionViewCell {
         self.backgroundColor = .clear
         self.isSelected = false
         
-        whiteView.do {
-            $0.backgroundColor = .white
-        }
-        
         dimView.do {
-            $0.backgroundColor = .gray600
+            $0.backgroundColor = .labelAction.withAlphaComponent(0.2)
+            $0.layer.borderColor = UIColor.labelAction.cgColor
+            $0.layer.borderWidth = 1
         }
         
         photoImageView.do {

--- a/ACON-iOS/ACON-iOS/Presentation/Album/View/PhotoCollectionViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Album/View/PhotoCollectionViewController.swift
@@ -26,7 +26,7 @@ class PhotoCollectionViewController: BaseNavViewController {
 
     private var isDataLoaded = false
     
-    var selectedIndexPath: IndexPath?
+    var selectedIndexPath: ObservablePattern<IndexPath> = ObservablePattern(nil)
     
     private var isLoading = false
     
@@ -48,6 +48,7 @@ class PhotoCollectionViewController: BaseNavViewController {
         addTarget()
         registerCell()
         bindViewModel()
+        bindSelectedIndexPath()
         setDelegate()
     }
     
@@ -100,7 +101,7 @@ private extension PhotoCollectionViewController {
     
     @objc
     func goToPhotoSelectionVC() {
-        albumViewModel.getHighQualityImage(index: selectedIndexPath?.item ?? 0) { [weak self] image in
+        albumViewModel.getHighQualityImage(index: selectedIndexPath.value?.item ?? 0) { [weak self] image in
             let vc = PhotoSelectionViewController(image)
             DispatchQueue.main.async {
                 self?.navigationController?.pushViewController(vc, animated: true)
@@ -121,6 +122,12 @@ private extension PhotoCollectionViewController {
                 self?.photoCollectionView.reloadData()
                 self?.albumViewModel.onSuccessLoadImages.value = false
             }
+        }
+    }
+    
+    func bindSelectedIndexPath() {
+        self.selectedIndexPath.bind { [weak self] selectedIndexPath in
+            self?.rightButton.isEnabled = (selectedIndexPath == nil) ? false : true
         }
     }
     
@@ -166,14 +173,15 @@ extension PhotoCollectionViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        if let previousIndexPath = selectedIndexPath {
+        if let previousIndexPath = selectedIndexPath.value {
             // NOTE: deselectItem 메소드 사용 시 가끔 오류
             if let cell = collectionView.cellForItem(at: previousIndexPath) as? PhotoCollectionViewCell {
                 cell.isSelected = false
+                selectedIndexPath.value = nil
             }
         }
         
-        selectedIndexPath = indexPath
+        selectedIndexPath.value = indexPath
         if let cell = collectionView.cellForItem(at: indexPath) as? PhotoCollectionViewCell {
             cell.isSelected = true
         }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/Component/ProfileGoogleAdView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/Component/ProfileGoogleAdView.swift
@@ -20,11 +20,7 @@ class ProfileGoogleAdView: BaseView {
     private let adButton = ACButton(style: GlassButton(glassmorphismType: .buttonGlassDefault, buttonType: .full_14_b1R), title: "광고")
     
     private let headlineLabel = UILabel()
-    
-    private let bodyLabel = UILabel()
-    
-    private let iconImageView = UIImageView()
-    
+
     private let mediaView = MediaView()
 
     private let callToActionButton = ACButton(style: GlassButton(glassmorphismType: .buttonGlassDefault, buttonType: .full_10_b1SB))
@@ -68,19 +64,22 @@ class ProfileGoogleAdView: BaseView {
         }
         
         adButton.snp.makeConstraints {
-            $0.top.trailing.equalToSuperview().inset(ScreenUtils.horizontalInset)
+            $0.top.leading.equalToSuperview().inset(10)
             $0.width.equalTo(48)
             $0.height.equalTo(28)
         }
         
         headlineLabel.snp.makeConstraints {
-            $0.top.leading.equalTo(ScreenUtils.horizontalInset)
-            $0.width.equalTo(210)
-            $0.height.equalTo(24)
+            $0.top.equalToSuperview().inset(46)
+            $0.leading.equalToSuperview().inset(10)
+            $0.width.equalTo(158)
+            $0.height.equalTo(48)
         }
 
         mediaView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.verticalEdges.trailing.equalToSuperview().inset(10)
+            $0.height.equalTo(120)
+            $0.width.equalTo(140*ScreenUtils.widthRatio)
         }
     }
     
@@ -96,7 +95,6 @@ class ProfileGoogleAdView: BaseView {
         skeletonView.isHidden = true
         
         mediaView.do {
-            $0.layer.cornerRadius = 8
             $0.clipsToBounds = true
         }
 
@@ -140,7 +138,7 @@ extension ProfileGoogleAdView {
         skeletonView.isHidden = true
         
         if let headline = nativeAd.headline {
-            headlineLabel.setLabel(text: headline, style: .t4SB)
+            headlineLabel.setLabel(text: headline, style: .t4SB, numberOfLines: 0)
             headlineLabel.isHidden = false
         } else {
             headlineLabel.isHidden = true

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileView.swift
@@ -174,9 +174,9 @@ final class ProfileView: BaseView {
         }
         
         googleAdView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(423*ScreenUtils.heightRatio)
-            $0.horizontalEdges.equalToSuperview().inset(20*ScreenUtils.widthRatio)
-            $0.height.equalTo(125*ScreenUtils.heightRatio)
+            $0.top.equalToSuperview().offset(431*ScreenUtils.heightRatio)
+            $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.horizontalInset)
+            $0.height.equalTo(140*ScreenUtils.heightRatio)
         }
     }
 

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/SpotListGoogleAdCollectionViewCell.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/SpotListGoogleAdCollectionViewCell.swift
@@ -86,18 +86,20 @@ class SpotListGoogleAdCollectionViewCell: BaseCollectionViewCell {
         
         headlineLabel.snp.makeConstraints {
             $0.top.leading.equalTo(edge)
-            $0.width.equalTo(210)
+            $0.width.equalTo(250)
             $0.height.equalTo(24)
         }
         
         bodyLabel.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(76*ScreenUtils.heightRatio)
             $0.horizontalEdges.equalToSuperview().inset(edge)
-            $0.height.equalTo(40)
+            $0.height.equalTo(60)
         }
         
         mediaView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.equalToSuperview().inset(104*ScreenUtils.heightRatio)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(212*ScreenUtils.heightRatio)
         }
         
         callToActionButton.snp.makeConstraints {


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #181

## 🥔 **작업 내용**
- 6/8 디자인QA - #8 사진 선택버튼 항상 활성화 이슈 QA 대응
- GoogleAdsManager crash 없도록 광고 로드 로직 개선
- SpotList, Profile 광고 뷰 UI 변경사항 반영

## 🚨 참고 사항
슬랙에 말씀드렸다시피 구글 애즈 레이아웃 에러 해결 관련 시도 사항은 temp/ad-layout-issue 브랜치에 커밋 2316689f99d075a016823f0e8608e4a3132569f5 해두었습니다!! 

`<Google> <Google:HTML> Not all asset views lie inside the native ad view. This indicates an integration problem. Such implementations will not be supported in the future. Please make sure that all native ad assets are rendered inside the native ad view.`

## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #181
