### PR TITLE
[FIX] 메뉴판 핀치 영역, 필터 바텀시트 UI 수정 (+ '장소'탭 선택 시 로직 구현) (#192)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -2172,7 +2172,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2025.0611.2239;
+				CURRENT_PROJECT_VERSION = 2025.0613.0425;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KX5Q77JSUF;
@@ -2216,7 +2216,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2025.0611.2239;
+				CURRENT_PROJECT_VERSION = 2025.0613.0425;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KX5Q77JSUF;
 				GENERATE_INFOPLIST_FILE = NO;

--- a/ACON-iOS/ACON-iOS/Global/Settings/Info.plist
+++ b/ACON-iOS/ACON-iOS/Global/Settings/Info.plist
@@ -42,7 +42,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2025.0611.2239</string>
+	<string>2025.0613.0425</string>
 	<key>GIDClientID</key>
 	<string>${GOOGLE_CLIENT_ID}</string>
 	<key>GOOGLE_WEB_CLIENT_ID</key>

--- a/ACON-iOS/ACON-iOS/Global/Utils/Enums/ACSheetDetentType.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/Enums/ACSheetDetentType.swift
@@ -12,7 +12,7 @@ enum ACSheetDetentType: String {
     case short
     case semiShort
     case middle
-    case long
+    case semiLong
 
     var identifier: UISheetPresentationController.Detent.Identifier {
         return UISheetPresentationController.Detent.Identifier(rawValue)
@@ -23,7 +23,7 @@ enum ACSheetDetentType: String {
         case .short: return 204
         case .semiShort: return 300
         case .middle: return 518
-        case .long: return 680
+        case .semiLong: return 592
         }
     }
 
@@ -52,7 +52,7 @@ extension ACSheetDetentType {
     }
 
     static var longDetent: UISheetPresentationController.Detent {
-        return long.detent
+        return semiLong.detent
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/Cell/MenuCollectionViewCell.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/Cell/MenuCollectionViewCell.swift
@@ -15,7 +15,7 @@ final class MenuCollectionViewCell: BaseCollectionViewCell {
 
     var onZooming: ((Bool) -> Void)?
 
-    private let glassBgView = GlassmorphismView(.noImageErrorGlass)
+    private let imageLoadErrorGlassBgView = GlassmorphismView(.noImageErrorGlass)
 
     private let imageView = UIImageView()
 
@@ -30,13 +30,13 @@ final class MenuCollectionViewCell: BaseCollectionViewCell {
     override func setHierarchy() {
         super.setHierarchy()
 
-        self.addSubviews(glassBgView, imageView, imageLoadErrorLabel)
+        contentView.addSubviews(imageLoadErrorGlassBgView, imageView, imageLoadErrorLabel)
     }
 
     override func setLayout() {
         super.setLayout()
 
-        glassBgView.snp.makeConstraints {
+        imageLoadErrorGlassBgView.snp.makeConstraints {
             $0.center.equalToSuperview()
             $0.width.equalTo(imageWidth)
             $0.height.equalTo(imageHeight)
@@ -58,14 +58,17 @@ final class MenuCollectionViewCell: BaseCollectionViewCell {
 
         self.backgroundColor = .clear
 
-        imageView.do {
+        contentView.do {
             let pinchGesture = UIPinchGestureRecognizer(target: self, action: #selector(zooming))
-            $0.contentMode = .scaleAspectFill
-            $0.clipsToBounds = true
             $0.isUserInteractionEnabled = true
             $0.addGestureRecognizer(pinchGesture)
         }
-        
+
+        imageView.do {
+            $0.contentMode = .scaleAspectFill
+            $0.clipsToBounds = true
+        }
+
         imageLoadErrorLabel.do {
             $0.isHidden = true
             $0.setLabel(text: StringLiterals.SpotList.imageLoadingFailed, style: .t5SB, color: .gray50)
@@ -83,7 +86,7 @@ final class MenuCollectionViewCell: BaseCollectionViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        glassBgView.refreshBlurEffect()
+        imageLoadErrorGlassBgView.refreshBlurEffect()
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -34,7 +34,6 @@ class SpotListViewController: BaseNavViewController {
         bindObservable()
         setCollectionView()
         addTarget()
-        viewModel.updateLocationAndPostSpotList()
         setSkeleton()
     }
 

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -51,7 +51,22 @@ class SpotListViewController: BaseNavViewController {
         ACToastController.hide()
         viewModel.stopPeriodicLocationCheck()
     }
-    
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        spotToggleButton.refreshBlurEffect()
+
+        for cell in spotListView.collectionView.visibleCells {
+            if let cell = cell as? SpotListCollectionViewCell {
+                cell.setNeedsLayout()
+           }
+       }
+    }
+
+
+    // MARK: - UI Settings
+
     override func setHierarchy() {
         super.setHierarchy()
 
@@ -110,16 +125,16 @@ class SpotListViewController: BaseNavViewController {
         )
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
+}
 
-        spotToggleButton.refreshBlurEffect()
 
-        for cell in spotListView.collectionView.visibleCells {
-            if let cell = cell as? SpotListCollectionViewCell {
-                cell.setNeedsLayout()
-           }
-       }
+// MARK: - Internal Methods
+
+extension SpotListViewController {
+
+    // NOTE: '장소' 탭 선택 시 호출
+    func refreshSpotList() {
+        handleRefreshControl()
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -132,8 +132,8 @@ class SpotListViewController: BaseNavViewController {
 extension SpotListViewController {
 
     // NOTE: '장소' 탭 선택 시 호출
-    func refreshSpotList() {
-        handleRefreshControl()
+    func goToTop() {
+        spotListView.collectionView.setContentOffset(.zero, animated: true)
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -242,7 +242,7 @@ private extension SpotListViewController {
         }
 
         let vc = SpotListFilterViewController(viewModel: viewModel)
-        vc.setSheetLayout(detent: .long)
+        vc.setSheetLayout(detent: .semiLong)
 
         present(vc, animated: true)
     }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -243,7 +243,6 @@ private extension SpotListViewController {
 
         let vc = SpotListFilterViewController(viewModel: viewModel)
         vc.setSheetLayout(detent: .long)
-        vc.isModalInPresentation = true
 
         present(vc, animated: true)
     }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/Type/SpotFilterType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/Type/SpotFilterType.swift
@@ -95,18 +95,16 @@ extension SpotFilterType {
 
     enum OpeningHoursOptionType: CaseIterable {
 
-        case overMidnight, overTenPM
+        case overTenPM
         
         var text: String {
             switch self {
-            case .overMidnight: return "밤 12시 이후"
             case .overTenPM: return "밤 10시 이후"
             }
         }
 
         var serverKey: String {
             switch self {
-            case .overMidnight: return "OPEN_AFTER_MIDNIGHT"
             case .overTenPM: return "OPEN_AFTER_10PM"
             }
         }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
@@ -224,8 +224,6 @@ private extension SpotListFilterView {
             config.background.strokeWidth = 1
             $0.configuration = config
 
-            $0.isEnabled = false
-
             // NOTE: 상태 변경에 따라 UI 업데이트
             $0.configurationUpdateHandler = { button in
                 switch button.state {
@@ -322,17 +320,6 @@ private extension SpotListFilterView {
         case .cafe:
             priceSectionView.isHidden = true
         }
-    }
-
-}
-
-
-// MARK: - Internal Methods (Update UI)
-
-extension SpotListFilterView {
-
-    func enableFooterButtons(_ isEnabled: Bool) {
-        [resetButton, conductButton].forEach { $0.isEnabled = isEnabled }
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
@@ -18,8 +18,6 @@ class SpotListFilterView: GlassmorphismView {
 
     private let pageTitleLabel = UILabel()
     
-    let exitButton = UIButton()
-    
     private let scrollView = UIScrollView()
     
     private let stackView = UIStackView()
@@ -86,7 +84,6 @@ class SpotListFilterView: GlassmorphismView {
         
         self.addSubviews(
             pageTitleLabel,
-            exitButton,
             scrollView,
             resetButton,
             conductButton
@@ -141,11 +138,6 @@ class SpotListFilterView: GlassmorphismView {
         pageTitleLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(33)
             $0.centerX.equalToSuperview()
-        }
-        
-        exitButton.snp.makeConstraints {
-            $0.centerY.equalTo(pageTitleLabel)
-            $0.trailing.equalToSuperview().offset(-horizontalEdge)
         }
         
         scrollView.snp.makeConstraints {
@@ -204,8 +196,6 @@ class SpotListFilterView: GlassmorphismView {
         pageTitleLabel.setLabel(
             text: StringLiterals.SpotListFilter.pageTitle,
             style: .t3SB)
-        
-        exitButton.setImage(.icDismiss, for: .normal)
         
         stackView.do {
             $0.axis = .vertical

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterView.swift
@@ -302,7 +302,7 @@ private extension SpotListFilterView {
     // MARK: - (Opening hours section)
     
     func setOpeningHoursSectionUI() {
-        let option: SpotFilterType.OpeningHoursOptionType = spotType == .restaurant ? .overMidnight : .overTenPM
+        let option: SpotFilterType.OpeningHoursOptionType = .overTenPM
 
         openingHoursSectionTitleLabel.setLabel(text: StringLiterals.SpotListFilter.openingHours, style: .t5SB)
         openingHoursButton.updateButtonTitle(option.text)

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
@@ -201,9 +201,7 @@ private extension SpotListFilterViewController {
         if spotListFilterView.openingHoursButton.isTagged {
             return SpotFilterModel(
                 category: .openingHours,
-                optionList: spotType == .restaurant
-                ? [SpotFilterType.OpeningHoursOptionType.overMidnight.serverKey]
-                : [SpotFilterType.OpeningHoursOptionType.overTenPM.serverKey]
+                optionList: [SpotFilterType.OpeningHoursOptionType.overTenPM.serverKey]
             )
         }
         return nil

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
@@ -18,7 +18,7 @@ class SpotListFilterViewController: BaseViewController {
     private var taggedFilterButtons: Set<FilterTagButton> = [] {
         didSet {
             let hasTaggedFilters = !taggedFilterButtons.isEmpty
-            spotListFilterView.enableFooterButtons(hasTaggedFilters)
+            spotListFilterView.conductButton.isEnabled = hasTaggedFilters
         }
     }
 

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
@@ -95,12 +95,6 @@ private extension SpotListFilterViewController {
 private extension SpotListFilterViewController {
 
     func addTargets() {
-        spotListFilterView.exitButton.addTarget(
-            self,
-            action: #selector(didTapExitButton),
-            for: .touchUpInside
-        )
-
         spotListFilterView.conductButton.addTarget(
             self,
             action: #selector(didTapConductButton),
@@ -120,11 +114,6 @@ private extension SpotListFilterViewController {
 // MARK: - @objc functions
 
 private extension SpotListFilterViewController {
-
-    @objc
-    func didTapExitButton() {
-        self.dismiss(animated: true)
-    }
 
     @objc
     func didTapConductButton() {

--- a/ACON-iOS/ACON-iOS/Presentation/TabBar/ACTabBarController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/TabBar/ACTabBarController.swift
@@ -111,7 +111,7 @@ extension ACTabBarController: UITabBarControllerDelegate {
             return
         }
 
-        spotListVC.refreshSpotList()
+        spotListVC.goToTop()
     }
 
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {

--- a/ACON-iOS/ACON-iOS/Presentation/TabBar/ACTabBarController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/TabBar/ACTabBarController.swift
@@ -101,7 +101,19 @@ extension ACTabBarController {
 // MARK: - UITabBarControllerDelegate
 
 extension ACTabBarController: UITabBarControllerDelegate {
-    
+
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        guard let viewControllers = viewControllers,
+              let index = viewControllers.firstIndex(of: viewController),
+              index == ACTabBarItemType.allCases.firstIndex(of: .spotList),
+              let nav = viewController as? UINavigationController,
+              let spotListVC = nav.viewControllers.first as? SpotListViewController else {
+            return
+        }
+
+        spotListVC.refreshSpotList()
+    }
+
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
         guard let viewControllers = viewControllers else { return true }
         guard let index = viewControllers.firstIndex(of: viewController) else { return true }
@@ -119,5 +131,5 @@ extension ACTabBarController: UITabBarControllerDelegate {
         }
         return true
     }
-    
+
 }


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #192 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
- **메뉴판 핀치 영역 수정** (이미지만 -> 셀 전체)
- **필터 바텀시트 UI 수정**
  - x버튼을 삭제하고 아래로 스와이프하여 내릴 수 있도록 설정
  - sheet detent 수정
  - 영업시간 `12시 이후` 삭제
  - 초기화 버튼은 항상 활성화, 결과보기는 칩이 선택됐을때만 활성화
- **장소리스트 리프레시 관련**
  - SpotListVC가 처음 호출될 때 postSpotList가 두 번 호출되는 문제 해결 (viewDidLoad, 토글 observable binding 중복)
  - '장소' 탭 선택 시 리스트 최상단으로 이동 구현

## 🚨 참고 사항
<!-- 참고사항을 적어주세요. -->

## 📸 스크린샷
|기능|메뉴판|필터|홈탭 선택 시 최상단 이동|
|:--:|:--:|:--:|:--:|
|아이폰 16 Pro|<img src = "https://github.com/user-attachments/assets/611dcc9d-253f-413f-af46-f5da85d2ecd7" width ="250">|<img src = "https://github.com/user-attachments/assets/9dc03481-8053-4afe-83c2-f0811d6681e4" width ="250">|<img src = "https://github.com/user-attachments/assets/a01289e6-38bb-4675-b9f6-b7b7d38d54e0" width ="250">|

## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #192 
