### PR TITLE
[FEAT] 2.0 수정된 API 반영 (#194)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1502D71B2DE9B7ED00A21D81 /* UICollectionReusableView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1502D71A2DE9B7ED00A21D81 /* UICollectionReusableView+.swift */; };
 		1502D71D2DE9D44100A21D81 /* RegionErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1502D71C2DE9D44100A21D81 /* RegionErrorView.swift */; };
+		1503DBEB2DFD9CBB001FC3E5 /* GetMenuboardImageListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1503DBEA2DFD9CBB001FC3E5 /* GetMenuboardImageListResponse.swift */; };
 		150A105C2DA28F2600B0BC9A /* ACTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 150A105B2DA28F2600B0BC9A /* ACTextField.swift */; };
 		151003EC2D5FBF7200409DF4 /* GetProfileResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151003EB2D5FBF7200409DF4 /* GetProfileResponse.swift */; };
 		151003EE2D5FC48B00409DF4 /* ProfileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151003ED2D5FC48B00409DF4 /* ProfileService.swift */; };
@@ -287,6 +288,7 @@
 /* Begin PBXFileReference section */
 		1502D71A2DE9B7ED00A21D81 /* UICollectionReusableView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionReusableView+.swift"; sourceTree = "<group>"; };
 		1502D71C2DE9D44100A21D81 /* RegionErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionErrorView.swift; sourceTree = "<group>"; };
+		1503DBEA2DFD9CBB001FC3E5 /* GetMenuboardImageListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMenuboardImageListResponse.swift; sourceTree = "<group>"; };
 		150A105B2DA28F2600B0BC9A /* ACTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACTextField.swift; sourceTree = "<group>"; };
 		151003EB2D5FBF7200409DF4 /* GetProfileResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProfileResponse.swift; sourceTree = "<group>"; };
 		151003ED2D5FC48B00409DF4 /* ProfileService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileService.swift; sourceTree = "<group>"; };
@@ -1088,6 +1090,7 @@
 			isa = PBXGroup;
 			children = (
 				746261822D3F9FC600A4E84F /* GetSpotMenuResponse.swift */,
+				1503DBEA2DFD9CBB001FC3E5 /* GetMenuboardImageListResponse.swift */,
 				7462617E2D3F9F0300A4E84F /* GetSpotDetailResponse.swift */,
 			);
 			path = DTO;
@@ -2003,6 +2006,7 @@
 				748ECA6B2D31918D00BBC981 /* LoginView.swift in Sources */,
 				D6EA38152D42B88F002B68B9 /* SearchEmptyView.swift in Sources */,
 				74D31C712D5832D000B4B2B4 /* AlbumViewModel.swift in Sources */,
+				1503DBEB2DFD9CBB001FC3E5 /* GetMenuboardImageListResponse.swift in Sources */,
 				1547A6F22D33AD4500E96616 /* SpotListModel.swift in Sources */,
 				746261732D3EA78700A4E84F /* GetReiviewVerificationRequest.swift in Sources */,
 				743900912DC50926002F91B1 /* UIVisualEffectView+.swift in Sources */,

--- a/ACON-iOS/ACON-iOS/Global/Resources/Assets.xcassets/Icons/2.0/ic_menu.imageset/Contents.json
+++ b/ACON-iOS/ACON-iOS/Global/Resources/Assets.xcassets/Icons/2.0/ic_menu.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetMenuboardImageListResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetMenuboardImageListResponse.swift
@@ -1,0 +1,14 @@
+//
+//  GetMenuboardImageListResponse.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 6/14/25.
+//
+
+import Foundation
+
+struct GetMenuboardImageListResponse: Decodable {
+
+    let menuboardImageList: [String]
+
+}

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetSpotDetailResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetSpotDetailResponse.swift
@@ -9,15 +9,25 @@ import Foundation
 
 struct GetSpotDetailResponse: Decodable {
     
-    let id: Int64
+    let spotId: Int64
     
-    let imageList: [String]
+    let imageList: [String]?
     
     let name: String
     
     let acornCount: Int
     
+    let tagList: [String]?
+    
+    let isOpen: Bool
+    
+    let closingTime: String
+    
+    let nextOpening: String
+    
     let hasMenuboardImage: Bool
+    
+    let isSaved: Bool
     
     let signatureMenuList: [SignatureMenuDTO]?
     

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailService.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailService.swift
@@ -78,7 +78,7 @@ final class SpotDetailService: BaseService<SpotDetailTargetType>,
     }
 
     func deleteSavedSpot(spotID: Int64, completion: @escaping (NetworkResult<EmptyResponse>) -> Void) {
-        self.provider.request(.postSavedSpot(spotID: spotID)) { result in
+        self.provider.request(.deleteSavedSpot(spotID: spotID)) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<EmptyResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data, type: EmptyResponse.self)

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailService.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailService.swift
@@ -15,6 +15,8 @@ protocol SpotDetailServiceProtocol {
                        completion: @escaping (NetworkResult<GetSpotDetailResponse>) -> Void)
     func getSpotMenu(spotID: Int64,
                      completion: @escaping (NetworkResult<GetSpotMenuResponse>) -> Void)
+    func getSpotMenuboardImageList(spotID: Int64,
+                                   completion: @escaping (NetworkResult<GetMenuboardImageListResponse>) -> Void)
     func postGuidedSpot(spotID: Int64,
                         completion: @escaping (NetworkResult<EmptyResponse>) -> Void)
     func postSavedSpot(spotID: Int64,
@@ -45,6 +47,19 @@ final class SpotDetailService: BaseService<SpotDetailTargetType>,
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<GetSpotMenuResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data, type: GetSpotMenuResponse.self)
+                completion(networkResult)
+            case .failure(let errorResponse):
+                print(errorResponse)
+            }
+        }
+    }
+
+    func getSpotMenuboardImageList(spotID: Int64,
+                                   completion: @escaping (NetworkResult<GetMenuboardImageListResponse>) -> Void) {
+        self.provider.request(.getMenuboardImageList(spotID: spotID)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<GetMenuboardImageListResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data, type: GetMenuboardImageListResponse.self)
                 completion(networkResult)
             case .failure(let errorResponse):
                 print(errorResponse)

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailService.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailService.swift
@@ -10,19 +10,23 @@ import Foundation
 import Moya
 
 protocol SpotDetailServiceProtocol {
-    
+
     func getSpotDetail(spotID: Int64,
                        completion: @escaping (NetworkResult<GetSpotDetailResponse>) -> Void)
     func getSpotMenu(spotID: Int64,
                      completion: @escaping (NetworkResult<GetSpotMenuResponse>) -> Void)
     func postGuidedSpot(spotID: Int64,
                         completion: @escaping (NetworkResult<EmptyResponse>) -> Void)
-    
+    func postSavedSpot(spotID: Int64,
+                       completion: @escaping (NetworkResult<EmptyResponse>) -> Void)
+    func deleteSavedSpot(spotID: Int64,
+                         completion: @escaping (NetworkResult<EmptyResponse>) -> Void)
+
 }
 
 final class SpotDetailService: BaseService<SpotDetailTargetType>,
                                SpotDetailServiceProtocol {
-    
+
     func getSpotDetail(spotID: Int64, completion: @escaping (NetworkResult<GetSpotDetailResponse>) -> Void) {
         self.provider.request(.getSpotDetail(spotID: spotID)) { result in
             switch result {
@@ -34,7 +38,7 @@ final class SpotDetailService: BaseService<SpotDetailTargetType>,
             }
         }
     }
-    
+
     func getSpotMenu(spotID: Int64,
                      completion: @escaping (NetworkResult<GetSpotMenuResponse>) -> Void) {
         self.provider.request(.getSpotMenu(spotID: spotID)) { result in
@@ -60,5 +64,29 @@ final class SpotDetailService: BaseService<SpotDetailTargetType>,
             }
         }
     }
-    
+
+    func postSavedSpot(spotID: Int64, completion: @escaping (NetworkResult<EmptyResponse>) -> Void) {
+        self.provider.request(.postSavedSpot(spotID: spotID)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<EmptyResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data, type: EmptyResponse.self)
+                completion(networkResult)
+            case .failure(let errorResponse):
+                print(errorResponse)
+            }
+        }
+    }
+
+    func deleteSavedSpot(spotID: Int64, completion: @escaping (NetworkResult<EmptyResponse>) -> Void) {
+        self.provider.request(.postSavedSpot(spotID: spotID)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<EmptyResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data, type: EmptyResponse.self)
+                completion(networkResult)
+            case .failure(let errorResponse):
+                print(errorResponse)
+            }
+        }
+    }
+
 }

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailTargetType.swift
@@ -14,6 +14,8 @@ enum SpotDetailTargetType {
     case getSpotDetail(spotID: Int64)
     case getSpotMenu(spotID: Int64)
     case postGuidedSpot(spotID: Int64)
+    case postSavedSpot(spotID: Int64)
+    case deleteSavedSpot(spotID: Int64)
     
 }
 
@@ -21,8 +23,10 @@ extension SpotDetailTargetType: TargetType {
 
     var method: Moya.Method {
         switch self {
-        case .postGuidedSpot:
+        case .postGuidedSpot, .postSavedSpot:
             return .post
+        case .deleteSavedSpot:
+            return .delete
         default:
             return .get
         }
@@ -36,12 +40,16 @@ extension SpotDetailTargetType: TargetType {
             return utilPath + "spots/\(spotID)/menus"
         case .postGuidedSpot:
             return utilPath + "guided-spots"
+        case .postSavedSpot:
+            return utilPath + "saved-spots"
+        case .deleteSavedSpot(let spotID):
+            return utilPath + "saved-spots/\(spotID)"
         }
     }
     
     var task: Task {
         switch self {
-        case .postGuidedSpot(let spotID):
+        case .postGuidedSpot(let spotID), .postSavedSpot(let spotID):
             return .requestParameters(parameters: ["spotId": spotID], encoding: JSONEncoding.default)
         default:
             return .requestPlain
@@ -55,8 +63,10 @@ extension SpotDetailTargetType: TargetType {
             headers = HeaderType.basicHeader
         case .getSpotMenu:
             headers = HeaderType.noHeader
-        case .postGuidedSpot:
+        case .postGuidedSpot, .postSavedSpot:
             headers = HeaderType.headerWithToken()
+        case .deleteSavedSpot:
+            headers = HeaderType.tokenOnly()
         }
         return headers
     }

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailTargetType.swift
@@ -13,6 +13,7 @@ enum SpotDetailTargetType {
     
     case getSpotDetail(spotID: Int64)
     case getSpotMenu(spotID: Int64)
+    case getMenuboardImageList(spotID: Int64)
     case postGuidedSpot(spotID: Int64)
     case postSavedSpot(spotID: Int64)
     case deleteSavedSpot(spotID: Int64)
@@ -38,6 +39,8 @@ extension SpotDetailTargetType: TargetType {
             return utilPath + "spots/\(spotID)"
         case .getSpotMenu(let spotID):
             return utilPath + "spots/\(spotID)/menus"
+        case .getMenuboardImageList(let spotID):
+            return utilPath + "spots/\(spotID)/menuboards"
         case .postGuidedSpot:
             return utilPath + "guided-spots"
         case .postSavedSpot:
@@ -61,7 +64,7 @@ extension SpotDetailTargetType: TargetType {
         switch self {
         case .getSpotDetail:
             headers = HeaderType.basicHeader
-        case .getSpotMenu:
+        case .getSpotMenu, .getMenuboardImageList:
             headers = HeaderType.noHeader
         case .postGuidedSpot, .postSavedSpot:
             headers = HeaderType.headerWithToken()

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailTargetType.swift
@@ -62,13 +62,11 @@ extension SpotDetailTargetType: TargetType {
     var headers: [String : String]? {
         var headers = HeaderType.noHeader
         switch self {
-        case .getSpotDetail:
-            headers = HeaderType.basicHeader
         case .getSpotMenu, .getMenuboardImageList:
             headers = HeaderType.noHeader
         case .postGuidedSpot, .postSavedSpot:
             headers = HeaderType.headerWithToken()
-        case .deleteSavedSpot:
+        case .getSpotDetail, .deleteSavedSpot:
             headers = HeaderType.tokenOnly()
         }
         return headers

--- a/ACON-iOS/ACON-iOS/Network/SpotList/DTO/PostSpotListResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotList/DTO/PostSpotListResponse.swift
@@ -17,7 +17,7 @@ struct PostSpotListResponse: Decodable {
 
 struct SpotDTO: Decodable {
 
-    let id: Int64
+    let spotId: Int64
 
     let image: String?
 
@@ -26,6 +26,12 @@ struct SpotDTO: Decodable {
     let acornCount: Int
 
     let tagList: [String]?
+
+    let isOpen: Bool
+
+    let closingTime: String
+
+    let nextOpening: String
 
     let eta: Int
 

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileViewController.swift
@@ -151,7 +151,7 @@ private extension ProfileViewController {
         guard let view = gesture.view else { return }
 
         guard let selectedSpotID = viewModel.userInfo.savedSpotList?[view.tag].id else { return }
-        let vc = SpotDetailViewController(selectedSpotID, [])
+        let vc = SpotDetailViewController(selectedSpotID)
         self.navigationController?.pushViewController(vc, animated: true)
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/SavedSpotsViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/SavedSpotsViewController.swift
@@ -147,7 +147,7 @@ extension SavedSpotsViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let selectedSpotID = viewModel.savedSpotList[indexPath.item].id
-        let vc = SpotDetailViewController(selectedSpotID, [])
+        let vc = SpotDetailViewController(selectedSpotID)
         self.navigationController?.pushViewController(vc, animated: true)
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/Model/SpotDetailModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/Model/SpotDetailModel.swift
@@ -5,29 +5,35 @@
 //  Created by 이수민 on 1/16/25.
 //
 
-
 import Foundation
-import UIKit
 
 struct SpotDetailInfoModel: Equatable {
 
     let spotID: Int64
 
-    let imageURLs: [String]
+    let imageURLs: [String]?
 
     let name: String
 
     let acornCount: Int
 
+    let tagList: [SpotTagType]?
+
+    let isOpen: Bool
+
+    let closingTime: String
+
+    let nextOpening: String
+
     let hasMenuboardImage: Bool
+
+    let isSaved: Bool
 
     let signatureMenuList: [SignatureMenuModel]
 
     let latitude: Double
 
     let longitude: Double
-
-    let tagList: [SpotTagType]
 
 }
 
@@ -44,20 +50,24 @@ struct SignatureMenuModel: Equatable {
 
 extension SpotDetailInfoModel {
 
-    init(from dto: GetSpotDetailResponse, tagList: [SpotTagType]) {
-        self.spotID = dto.id
+    init(from dto: GetSpotDetailResponse) {
+        self.spotID = dto.spotId
         self.imageURLs = dto.imageList
         self.name = dto.name
         self.acornCount = dto.acornCount
+        self.tagList = dto.tagList?.map { SpotTagType(rawValue: $0) }
+        
+        self.isOpen = dto.isOpen
+        self.closingTime = dto.closingTime
+        self.nextOpening = dto.nextOpening
         self.hasMenuboardImage = dto.hasMenuboardImage
+        self.isSaved = dto.isSaved
 
         let menuList = dto.signatureMenuList ?? []
         self.signatureMenuList = menuList.map { SignatureMenuModel(from: $0) }
 
         self.latitude = dto.latitude
         self.longitude = dto.longitude
-
-        self.tagList = tagList
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/Cell/MenuCollectionViewCell.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/Cell/MenuCollectionViewCell.swift
@@ -60,7 +60,7 @@ final class MenuCollectionViewCell: BaseCollectionViewCell {
 
         imageView.do {
             let pinchGesture = UIPinchGestureRecognizer(target: self, action: #selector(zooming))
-            $0.contentMode = .scaleAspectFill
+            $0.contentMode = .scaleAspectFit
             $0.clipsToBounds = true
             $0.isUserInteractionEnabled = true
             $0.addGestureRecognizer(pinchGesture)
@@ -76,7 +76,7 @@ final class MenuCollectionViewCell: BaseCollectionViewCell {
         super.prepareForReuse()
 
         imageView.image = nil
-
+        glassBgView.isHidden = true
         imageLoadErrorLabel.isHidden = true
     }
 
@@ -124,9 +124,11 @@ extension MenuCollectionViewCell {
             completionHandler: { result in
                 switch result {
                 case .success:
+                    self.glassBgView.isHidden = true
                     self.imageLoadErrorLabel.isHidden = true
                 case .failure:
                     self.imageView.image = nil
+                    self.glassBgView.isHidden = false
                     self.imageLoadErrorLabel.isHidden = false
                 }
             }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/Component/SpotDetailSideButton.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/Component/SpotDetailSideButton.swift
@@ -11,6 +11,8 @@ class SpotDetailSideButton: UIView {
 
     // MARK: - Property & Initializer
 
+    var onTap: ((Bool) -> Void)?
+
     let type: SideButtonType
     var isSelected: Bool = false {
         didSet {
@@ -110,7 +112,7 @@ private extension SpotDetailSideButton {
     @objc
     func tappedSelf() {
         isSelected.toggle()
-        print("isSelected: \(isSelected)")
+        onTap?(isSelected)
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/Component/SpotDetailSideButton.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/Component/SpotDetailSideButton.swift
@@ -14,9 +14,17 @@ class SpotDetailSideButton: UIView {
     var onTap: ((Bool) -> Void)?
 
     let type: SideButtonType
+
     var isSelected: Bool = false {
         didSet {
             imageView.image = isSelected ? type.selectedImage : type.defaultImage
+        }
+    }
+
+    var isEnabled: Bool = true {
+        didSet {
+            imageView.tintColor = isEnabled ? .acWhite : .gray300
+            label.textColor = isEnabled ? .acWhite : .gray300
         }
     }
 
@@ -69,6 +77,7 @@ private extension SpotDetailSideButton {
     func setStyle() {
         imageView.do {
             $0.image = isSelected ? type.selectedImage : type.defaultImage
+            $0.tintColor = .acWhite
             $0.contentMode = .scaleAspectFit
 
             $0.layer.do {
@@ -111,6 +120,7 @@ private extension SpotDetailSideButton {
 
     @objc
     func tappedSelf() {
+        guard isEnabled else { return }
         isSelected.toggle()
         onTap?(isSelected)
     }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailView.swift
@@ -168,25 +168,43 @@ extension SpotDetailView {
 
         setAcornCountButton(with: spotDetail.acornCount)
 
-        tagStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        spotDetail.tagList.forEach { tag in
-            tagStackView.addArrangedSubview(SpotTagButton(tag))
-        }
-
         // TODO: 바인딩 수정 - 이전 뷰에서 넘겨받기
         findCourseButton.setAttributedTitle(text: "도보 9분 길찾기", style: .t4SB)
 
-        if spotDetail.imageURLs.count == 0 {
+        if spotDetail.imageURLs?.count == 0 {
             [noImageBgImageView, noImageContentView].forEach { $0.isHidden = false }
             noImageContentView.setDescription(.noImageDynamic(id: Int(spotDetail.spotID)))
         }
 
         // TODO: API 명세 나오면 실제 데이터로 바꾸기
-        bookmarkButton.isSelected = false
+        bookmarkButton.isSelected = spotDetail.isSaved
         
-        setImagePageControl(spotDetail.imageURLs.count)
+        setImagePageControl(spotDetail.imageURLs?.count)
+    }
 
-        setOpeningTimeView(withTags: !spotDetail.tagList.isEmpty)
+    func setTagStackView(tags: [SpotTagType]) {
+        tagStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        tags.forEach { tag in
+            tagStackView.addArrangedSubview(SpotTagButton(tag))
+        }
+    }
+
+    func setOpeningTimeView(isOpen: Bool, time: String, description: String, hasTags: Bool) {
+        let openingTimeView = OpeningTimeView(isOpen: isOpen, time: time, description: description)
+
+        self.addSubview(openingTimeView)
+
+        if hasTags {
+            openingTimeView.snp.makeConstraints {
+                $0.top.equalTo(tagStackView.snp.bottom).offset(7)
+                $0.leading.equalToSuperview().offset(horizontalEdges)
+            }
+        } else {
+            openingTimeView.snp.makeConstraints {
+                $0.top.equalTo(titleLabel.snp.bottom).offset(7)
+                $0.leading.equalToSuperview().offset(horizontalEdges)
+            }
+        }
     }
 
     func makeSignatureMenuSection(_ menus: [SignatureMenuModel]) {
@@ -261,31 +279,18 @@ private extension SpotDetailView {
         return stackView
     }
 
-    func setImagePageControl(_ numberOfPages: Int) {
+    func setImagePageControl(_ numberOfPages: Int?) {
+        guard let numberOfPages = numberOfPages else {
+            imagePageControl.removeFromSuperview()
+            return
+        }
+
         imagePageControl.do {
             $0.numberOfPages = numberOfPages
             $0.currentPage = 0
             $0.currentPageIndicatorTintColor = .acWhite
             $0.pageIndicatorTintColor = .gray300
             $0.transform = CGAffineTransform(scaleX: 0.85, y: 0.85)
-        }
-    }
-
-    func setOpeningTimeView(withTags: Bool) {
-        let openingTimeView = OpeningTimeView(type: .end, time: "22:00", withDot: true) //TODO: 명세 나오면 수정
-
-        self.addSubview(openingTimeView)
-
-        if withTags {
-            openingTimeView.snp.makeConstraints {
-                $0.top.equalTo(tagStackView.snp.bottom).offset(7)
-                $0.leading.equalToSuperview().offset(horizontalEdges)
-            }
-        } else {
-            openingTimeView.snp.makeConstraints {
-                $0.top.equalTo(titleLabel.snp.bottom).offset(7)
-                $0.leading.equalToSuperview().offset(horizontalEdges)
-            }
         }
     }
 

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
@@ -100,6 +100,9 @@ class SpotDetailViewController: BaseNavViewController {
 
         let menuTapGesture = UITapGestureRecognizer(target: self, action: #selector(tappedMenuButton))
         spotDetailView.menuButton.addGestureRecognizer(menuTapGesture)
+
+        let bookmarkTapGesture = UITapGestureRecognizer(target: self, action: #selector(tappedBookmarkButton))
+        spotDetailView.bookmarkButton.addGestureRecognizer(bookmarkTapGesture)
     }
 
 }
@@ -120,9 +123,24 @@ private extension SpotDetailViewController {
             } else {
                 self?.showDefaultAlert(title: "장소 정보 로드 실패", message: "장소 정보 로드에 실패했습니다.")
             }
+            self?.viewModel.onSuccessGetSpotDetail.value = nil
 #if DEBUG
             self?.spotDetailView.collectionView.reloadData() // TODO: 삭제하고 다른 UI 설정
 #endif
+        }
+
+        self.viewModel.onSuccessPostSavedSpot.bind { [weak self] onSuccess in
+            guard let onSuccess,
+                  let self = self else { return }
+            spotDetailView.menuButton.isSelected = onSuccess
+            viewModel.onSuccessPostSavedSpot.value = nil
+        }
+
+        self.viewModel.onSuccessDeleteSavedSpot.bind { [weak self] onSuccess in
+            guard let onSuccess,
+                  let self = self else { return }
+            spotDetailView.menuButton.isSelected = !onSuccess
+            viewModel.onSuccessPostSavedSpot.value = nil
         }
     }
 
@@ -163,6 +181,11 @@ private extension SpotDetailViewController {
         let vc = MenuImageSlideViewController(viewModel.menuImageURLs)
         vc.modalPresentationStyle = .overFullScreen
         self.present(vc, animated: true)
+    }
+
+    @objc
+    func tappedBookmarkButton() {
+        spotDetailView.bookmarkButton.isSelected ? viewModel.deleteSavedSpot() : viewModel.postSavedSpot()
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
@@ -40,7 +40,7 @@ class SpotDetailViewController: BaseNavViewController {
 
         setDelegate()
         registerCell()
-        addTarget()
+        setButtonAction()
         bindViewModel()
     }
 
@@ -93,7 +93,7 @@ class SpotDetailViewController: BaseNavViewController {
         spotDetailView.collectionView.register(SpotDetailImageCollectionViewCell.self, forCellWithReuseIdentifier: SpotDetailImageCollectionViewCell.cellIdentifier)
     }
 
-    private func addTarget() {
+    private func setButtonAction() {
         spotDetailView.findCourseButton.addTarget(self,
                                                   action: #selector(tappedFindCourseButton),
                                                   for: .touchUpInside)
@@ -101,8 +101,10 @@ class SpotDetailViewController: BaseNavViewController {
         let menuTapGesture = UITapGestureRecognizer(target: self, action: #selector(tappedMenuButton))
         spotDetailView.menuButton.addGestureRecognizer(menuTapGesture)
 
-        let bookmarkTapGesture = UITapGestureRecognizer(target: self, action: #selector(tappedBookmarkButton))
-        spotDetailView.bookmarkButton.addGestureRecognizer(bookmarkTapGesture)
+        spotDetailView.bookmarkButton.onTap = { [weak self] isSelected in
+            guard let self = self else { return }
+            isSelected ? viewModel.postSavedSpot() : viewModel.deleteSavedSpot()
+        }
     }
 
 }
@@ -181,11 +183,6 @@ private extension SpotDetailViewController {
         let vc = MenuImageSlideViewController(viewModel.menuImageURLs)
         vc.modalPresentationStyle = .overFullScreen
         self.present(vc, animated: true)
-    }
-
-    @objc
-    func tappedBookmarkButton() {
-        spotDetailView.bookmarkButton.isSelected ? viewModel.deleteSavedSpot() : viewModel.postSavedSpot()
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
@@ -50,6 +50,7 @@ class SpotDetailViewController: BaseNavViewController {
         self.tabBarController?.tabBar.isHidden = true
 
         viewModel.getSpotDetail()
+        viewModel.getMenuboardImageList()
         startTime = Date()
     }
 
@@ -135,17 +136,29 @@ private extension SpotDetailViewController {
 #endif
         }
 
+        self.viewModel.onSuccessGetMenuboardImageList.bind { [weak self] onSuccess in
+            guard let onSuccess,
+                  let self = self else { return }
+            
+            if onSuccess {
+                spotDetailView.menuButton.isEnabled = !viewModel.menuImageURLs.isEmpty
+            } else {
+                spotDetailView.menuButton.isEnabled = false
+            }
+            
+        }
+
         self.viewModel.onSuccessPostSavedSpot.bind { [weak self] onSuccess in
             guard let onSuccess,
                   let self = self else { return }
-            spotDetailView.menuButton.isSelected = onSuccess
+            spotDetailView.bookmarkButton.isSelected = onSuccess
             viewModel.onSuccessPostSavedSpot.value = nil
         }
 
         self.viewModel.onSuccessDeleteSavedSpot.bind { [weak self] onSuccess in
             guard let onSuccess,
                   let self = self else { return }
-            spotDetailView.menuButton.isSelected = !onSuccess
+            spotDetailView.bookmarkButton.isSelected = !onSuccess
             viewModel.onSuccessPostSavedSpot.value = nil
         }
     }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
@@ -98,8 +98,12 @@ class SpotDetailViewController: BaseNavViewController {
                                                   action: #selector(tappedFindCourseButton),
                                                   for: .touchUpInside)
 
-        let menuTapGesture = UITapGestureRecognizer(target: self, action: #selector(tappedMenuButton))
-        spotDetailView.menuButton.addGestureRecognizer(menuTapGesture)
+        spotDetailView.menuButton.onTap = { [weak self] _ in
+            guard let self = self else { return }
+            let vc = MenuImageSlideViewController(viewModel.menuImageURLs)
+            vc.modalPresentationStyle = .overFullScreen
+            self.present(vc, animated: true)
+        }
 
         spotDetailView.bookmarkButton.onTap = { [weak self] isSelected in
             guard let self = self else { return }
@@ -176,13 +180,6 @@ private extension SpotDetailViewController {
             $0.addAction(UIAlertAction(title: StringLiterals.Alert.cancel, style: .cancel, handler: nil))
         }
         present(alertController, animated: true)
-    }
-
-    @objc
-    func tappedMenuButton() {
-        let vc = MenuImageSlideViewController(viewModel.menuImageURLs)
-        vc.modalPresentationStyle = .overFullScreen
-        self.present(vc, animated: true)
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -19,7 +19,7 @@ class SpotDetailViewModel: Serviceable {
     var onSuccessPostSavedSpot: ObservablePattern<Bool> = ObservablePattern(nil)
     var onSuccessDeleteSavedSpot: ObservablePattern<Bool> = ObservablePattern(nil)
 
-    var spotDetail: ObservablePattern<SpotDetailInfoModel> = ObservablePattern(nil)
+    var spotDetail: SpotDetailInfoModel? = nil
 
     var menuImageURLs: [String] = []
 
@@ -38,7 +38,7 @@ extension SpotDetailViewModel {
             switch response {
             case .success(let data):
                 let spotDetailData = SpotDetailInfoModel(from: data)
-                self?.spotDetail.value = spotDetailData
+                self?.spotDetail = spotDetailData
                 self?.onSuccessGetSpotDetail.value = true
             case .reIssueJWT:
                 self?.handleReissue { [weak self] in

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -16,6 +16,7 @@ class SpotDetailViewModel: Serviceable {
     let tagList: [SpotTagType]
     
     let onSuccessGetSpotDetail: ObservablePattern<Bool> = ObservablePattern(nil)
+    let onSuccessGetMenuboardImageList: ObservablePattern<Bool> = ObservablePattern(nil)
     var onSuccessPostSavedSpot: ObservablePattern<Bool> = ObservablePattern(nil)
     var onSuccessDeleteSavedSpot: ObservablePattern<Bool> = ObservablePattern(nil)
         
@@ -83,6 +84,23 @@ extension SpotDetailViewModel {
 ////                return
 //            }
 //        }
+    }
+
+    func getMenuboardImageList() {
+        ACService.shared.spotDetailService.getSpotMenuboardImageList(spotID: spotID) { [weak self] response in
+            switch response {
+            case .success(let data):
+                self?.menuImageURLs = data.menuboardImageList
+                self?.onSuccessGetMenuboardImageList.value = true
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.getMenuboardImageList()
+                }
+            default:
+                self?.onSuccessGetMenuboardImageList.value = false
+                return
+            }
+        }
     }
 
     func postGuidedSpot() {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -11,44 +11,20 @@ import CoreLocation
 import MapKit
 
 class SpotDetailViewModel: Serviceable {
-    
+
     let spotID: Int64
-    let tagList: [SpotTagType]
-    
+
     let onSuccessGetSpotDetail: ObservablePattern<Bool> = ObservablePattern(nil)
     let onSuccessGetMenuboardImageList: ObservablePattern<Bool> = ObservablePattern(nil)
     var onSuccessPostSavedSpot: ObservablePattern<Bool> = ObservablePattern(nil)
     var onSuccessDeleteSavedSpot: ObservablePattern<Bool> = ObservablePattern(nil)
-        
+
     var spotDetail: ObservablePattern<SpotDetailInfoModel> = ObservablePattern(nil)
 
-    // TODO: DTO 수정 후 삭제
-    private lazy var spotDetailDummy = SpotDetailInfoModel(
-        spotID: spotID,
-        imageURLs: self.spotID == 1 ? [] : imageURLs,
-        name: self.spotID == 1 ? "이미지없는 식당" : "장소상세더미장소상세더미장소상세더미장소상세더미장소상세더미장소상세더미장소상세더미",
-        acornCount: 10000,
-        hasMenuboardImage: true,
-        signatureMenuList: [
-            SignatureMenuModel(name: "Free", price: 0),
-            SignatureMenuModel(name: "맛있는메뉴1", price: 13000),
-            SignatureMenuModel(name: "Very loooong name", price: 999999)
-        ],
-        latitude: 37.587038,
-        longitude: 127.0310,
-        tagList: tagList
-    )
-    
-    let imageURLs: [String] = ["https://i.pinimg.com/originals/05/b4/fb/05b4fbc3f169175e6deb97b3977175b6.jpg","wrongURL","https://cdn.kmecnews.co.kr/news/photo/202311/32217_20955_828.jpg","https://images.immediate.co.uk/production/volatile/sites/30/2022/03/Pancake-grazing-board-bc15106.jpg?quality=90&resize=556,505","https://natashaskitchen.com/wp-content/uploads/2020/03/Pan-Seared-Steak-4.jpg","https://i.namu.wiki/i/oFHlYDjoEh8f-cc3lNK9jAemRkbXxNGwUg7XiW5LGS6DF1P2x8GCeNQxbQhVIwtUS1u53YPw-uoyqpmLtrGNJA.webp","https://i.namu.wiki/i/dgjXU86ae29hDSCza-L0GZlFt3T9lRx1Ug9cKtqWSzMzs7Cd0CN2SzyLFEJcHVFviKcxAlIwxcllT9s2sck0RA.jpg","https://www.bhc.co.kr/upload/bhc/menu/%EC%96%91%EB%85%90%EC%B9%98%ED%82%A8_%EC%BD%A4%EB%B3%B4_410x271.jpg","https://cdn.kmecnews.co.kr/news/photo/202311/32217_20955_828.jpg"]
     var menuImageURLs: [String] = []
 
-    var mapType: String = "APPLE"
-    
-    let sname = "내 위치"
-    
-    init(_ spotID: Int64, _ tagList: [SpotTagType]) {
+    init(_ spotID: Int64) {
         self.spotID = spotID
-        self.tagList = tagList
     }
 
 }
@@ -58,31 +34,21 @@ class SpotDetailViewModel: Serviceable {
 extension SpotDetailViewModel {
     
     func getSpotDetail() {
-        self.spotDetail.value = spotDetailDummy
-        self.onSuccessGetSpotDetail.value = true
-//        ACService.shared.spotDetailService.getSpotDetail(spotID: spotID) { [weak self] response in
-//            switch response {
-//            case .success(let data):
-//                let spotDetailData = SpotDetailInfoModel(from: data, tagList: self?.tagList ?? [])
-//                self?.spotDetail.value = spotDetailData
-//                self?.onSuccessGetSpotDetail.value = true
-//            case .reIssueJWT:
-//                self?.handleReissue { [weak self] in
-//                    self?.getSpotDetail()
-//                }
-//            default:
-//                print("VM - Failed To getSpotDetail")
-////#if DEBUG
-//                // TODO: 삭제
-//                self?.spotDetail.value = self?.spotDetailDummy
-//                self?.onSuccessGetSpotDetail.value = true
-//                return
-////#endif
-//                // TODO: 주석 해제
-////                self?.onSuccessGetSpotDetail.value = false
-////                return
-//            }
-//        }
+        ACService.shared.spotDetailService.getSpotDetail(spotID: spotID) { [weak self] response in
+            switch response {
+            case .success(let data):
+                let spotDetailData = SpotDetailInfoModel(from: data)
+                self?.spotDetail.value = spotDetailData
+                self?.onSuccessGetSpotDetail.value = true
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.getSpotDetail()
+                }
+            default:
+                self?.onSuccessGetSpotDetail.value = false
+                return
+            }
+        }
     }
 
     func getMenuboardImageList() {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -16,6 +16,8 @@ class SpotDetailViewModel: Serviceable {
     let tagList: [SpotTagType]
     
     let onSuccessGetSpotDetail: ObservablePattern<Bool> = ObservablePattern(nil)
+    var onSuccessPostSavedSpot: ObservablePattern<Bool> = ObservablePattern(nil)
+    var onSuccessDeleteSavedSpot: ObservablePattern<Bool> = ObservablePattern(nil)
         
     var spotDetail: ObservablePattern<SpotDetailInfoModel> = ObservablePattern(nil)
 
@@ -93,10 +95,43 @@ extension SpotDetailViewModel {
                     self?.postGuidedSpot()
                 }
             default:
-                print("VM - Failed To postGuidedSpot")
                 return
             }
         }
     }
-    
+
+    func postSavedSpot() {
+        ACService.shared.spotDetailService.postSavedSpot(spotID: spotID){ [weak self] response in
+            switch response {
+            case .success:
+                self?.onSuccessPostSavedSpot.value = true
+                return
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.postGuidedSpot()
+                }
+            default:
+                self?.onSuccessPostSavedSpot.value = false
+                return
+            }
+        }
+    }
+
+    func deleteSavedSpot() {
+        ACService.shared.spotDetailService.postSavedSpot(spotID: spotID){ [weak self] response in
+            switch response {
+            case .success:
+                self?.onSuccessDeleteSavedSpot.value = true
+                return
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.postGuidedSpot()
+                }
+            default:
+                self?.onSuccessDeleteSavedSpot.value = false
+                return
+            }
+        }
+    }
+
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -118,7 +118,7 @@ extension SpotDetailViewModel {
     }
 
     func deleteSavedSpot() {
-        ACService.shared.spotDetailService.postSavedSpot(spotID: spotID){ [weak self] response in
+        ACService.shared.spotDetailService.deleteSavedSpot(spotID: spotID){ [weak self] response in
             switch response {
             case .success:
                 self?.onSuccessDeleteSavedSpot.value = true

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -40,8 +40,7 @@ class SpotDetailViewModel: Serviceable {
     )
     
     let imageURLs: [String] = ["https://i.pinimg.com/originals/05/b4/fb/05b4fbc3f169175e6deb97b3977175b6.jpg","wrongURL","https://cdn.kmecnews.co.kr/news/photo/202311/32217_20955_828.jpg","https://images.immediate.co.uk/production/volatile/sites/30/2022/03/Pancake-grazing-board-bc15106.jpg?quality=90&resize=556,505","https://natashaskitchen.com/wp-content/uploads/2020/03/Pan-Seared-Steak-4.jpg","https://i.namu.wiki/i/oFHlYDjoEh8f-cc3lNK9jAemRkbXxNGwUg7XiW5LGS6DF1P2x8GCeNQxbQhVIwtUS1u53YPw-uoyqpmLtrGNJA.webp","https://i.namu.wiki/i/dgjXU86ae29hDSCza-L0GZlFt3T9lRx1Ug9cKtqWSzMzs7Cd0CN2SzyLFEJcHVFviKcxAlIwxcllT9s2sck0RA.jpg","https://www.bhc.co.kr/upload/bhc/menu/%EC%96%91%EB%85%90%EC%B9%98%ED%82%A8_%EC%BD%A4%EB%B3%B4_410x271.jpg","https://cdn.kmecnews.co.kr/news/photo/202311/32217_20955_828.jpg"]
-    let menuImageURLs: [String] = ["https://marketplace.canva.com/EAGEDq-_tZQ/1/0/1035w/canva-grey-and-beige-minimalist-restaurant-menu-hb5BNMWcQS4.jpg","WrongURL","https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSmR-HwbkD_gFMN5Mv3fKRikt-IeJpYbayxAQ&s","https://t3.ftcdn.net/jpg/01/75/06/34/360_F_175063465_nPAUPd3x4uoqbmKyGqDLRDsIvMejnraQ.jpg","https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS3fjP3BWKbK_YDzsVBsI3EXKr7q0JCYMZWKQ&s"
-    ]
+    var menuImageURLs: [String] = []
 
     var mapType: String = "APPLE"
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/Model/SpotListModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/Model/SpotListModel.swift
@@ -19,7 +19,7 @@ struct SpotListModel {
 
 struct SpotModel: Equatable {
 
-    let id: Int64
+    let spotId: Int64
 
     let imageURL: String?
 
@@ -28,6 +28,12 @@ struct SpotModel: Equatable {
     let acornCount: Int
 
     let tagList: [SpotTagType]
+
+    let isOpen: Bool
+
+    let closingTime: String
+
+    let nextOpening: String
 
     let eta: Int
 
@@ -64,13 +70,17 @@ extension SpotListModel {
 extension SpotModel {
 
     init(from dto: SpotDTO) {
-        self.id = dto.id
+        self.spotId = dto.spotId
         self.imageURL = dto.image
         self.name = dto.name
         self.acornCount = dto.acornCount
 
         let tagList = dto.tagList ?? []
         self.tagList = tagList.map { SpotTagType(rawValue: $0) }
+
+        self.isOpen = dto.isOpen
+        self.closingTime = dto.closingTime
+        self.nextOpening = dto.nextOpening
 
         self.eta = dto.eta
         self.latitude = dto.latitude

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/Protocol/SpotListCellConfigurable.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/Protocol/SpotListCellConfigurable.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol SpotListCellConfigurable {
 
     func bind(spot: SpotModel)
+    func setTags(tags: [SpotTagType])
     func overlayLoginLock(_ show: Bool)
     func setFindCourseDelegate(_ delegate: SpotListCellDelegate?)
 

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/NoMatchingSpotListCollectionViewCell.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/NoMatchingSpotListCollectionViewCell.swift
@@ -258,6 +258,11 @@ extension NoMatchingSpotListCollectionViewCell: SpotListCellConfigurable {
         setFindCourseButton(with: spot.eta)
     }
 
+    func setTags(tags: [SpotTagType]) {
+        tagStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        setTagStackView(with: tags)
+    }
+
     func overlayLoginLock(_ show: Bool) {
         loginLockOverlayView.isHidden = !show
     }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/SpotListCollectionViewCell.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/SpotListCollectionViewCell.swift
@@ -251,9 +251,9 @@ extension SpotListCollectionViewCell: SpotListCellConfigurable {
 
         if let imageURL = spot.imageURL {
             currentImageURL = imageURL
-            setBgImageAndShadow(from: imageURL, noImageDescriptionID: Int(spot.id))
+            setBgImageAndShadow(from: imageURL, noImageDescriptionID: Int(spot.spotId))
         } else {
-            updateUI(with: .noImageDynamic(id: Int(spot.id)))
+            updateUI(with: .noImageDynamic(id: Int(spot.spotId)))
             extractAndApplyShadowColor(from: .imgSpotNoImageBackground, for: ShadowColorCache.noImageKey)
         }
 

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/SpotListCollectionViewCell.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/SpotListCollectionViewCell.swift
@@ -266,11 +266,14 @@ extension SpotListCollectionViewCell: SpotListCellConfigurable {
 
         setAcornCountButton(with: spot.acornCount)
 
-        spot.tagList.forEach { tag in
+        setFindCourseButton(with: spot.eta)
+    }
+
+    func setTags(tags: [SpotTagType]) {
+        tagStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        tags.forEach { tag in
             tagStackView.addArrangedSubview(SpotTagButton(tag))
         }
-
-        setFindCourseButton(with: spot.eta)
     }
 
     func overlayLoginLock(_ show: Bool) {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/SpotListSkeletonHeader.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/SpotListSkeletonHeader.swift
@@ -56,6 +56,7 @@ class SpotListSkeletonHeader: UICollectionReusableView {
         }
 
         skeletonView.do {
+            $0.clipsToBounds = true
             $0.layer.cornerRadius = 8
             $0.isSkeletonable = true
             $0.skeletonCornerRadius = 8

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Component/OpeningTimeView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Component/OpeningTimeView.swift
@@ -11,9 +11,11 @@ class OpeningTimeView: BaseView {
 
     // MARK: - Data
 
-    private let timeType: OpeningTimeType
+    private var isOpen: Bool
+
     private var time: String
-    private let withDot: Bool
+
+    private var openingDescription: String
 
 
     // MARK: - UI Properties
@@ -27,10 +29,10 @@ class OpeningTimeView: BaseView {
 
     // MARK: - Initializer
 
-    init(type: OpeningTimeType, time: String, withDot: Bool) {
-        self.timeType = type
+    init(isOpen: Bool, time: String, description: String) {
+        self.isOpen = isOpen
         self.time = time
-        self.withDot = withDot
+        self.openingDescription = description
 
         super.init(frame: .zero)
     }
@@ -55,21 +57,15 @@ class OpeningTimeView: BaseView {
             $0.height.greaterThanOrEqualTo(24)
         }
 
-        if withDot {
-            dotImageView.snp.makeConstraints {
-                $0.leading.equalToSuperview().offset(-6)
-                $0.centerY.equalToSuperview()
-                $0.size.equalTo(24)
-            }
-            
-            timeLabel.snp.makeConstraints {
-                $0.leading.equalTo(dotImageView.snp.trailing).offset(-2)
-                $0.centerY.equalTo(dotImageView)
-            }
-        } else {
-            timeLabel.snp.makeConstraints {
-                $0.leading.centerY.equalToSuperview()
-            }
+        dotImageView.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(-6)
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(24)
+        }
+
+        timeLabel.snp.makeConstraints {
+            $0.leading.equalTo(dotImageView.snp.trailing).offset(-2)
+            $0.centerY.equalTo(dotImageView)
         }
         
         descriptionLabel.snp.makeConstraints {
@@ -82,38 +78,13 @@ class OpeningTimeView: BaseView {
         self.backgroundColor = .clear
 
         dotImageView.do {
-            $0.image = timeType.dotImage
+            $0.image = isOpen ? .icGreenlight : .icGraylight
             $0.contentMode = .scaleAspectFit
         }
 
         timeLabel.setLabel(text: time, style: .b1SB, color: .gray200)
 
-        descriptionLabel.setLabel(text: timeType.description, style: .b1R, color: .gray200)
-    }
-
-}
-
-
-// MARK: - enum
-
-extension OpeningTimeView {
-
-    enum OpeningTimeType {
-        case start, end
-
-        var dotImage: UIImage {
-            switch self {
-            case .start: return .icGraylight
-            case .end: return .icGreenlight
-            }
-        }
-
-        var description: String {
-            switch self {
-            case .start: return StringLiterals.SpotList.businessStart
-            case .end: return StringLiterals.SpotList.businessEnd
-            }
-        }
+        descriptionLabel.setLabel(text: openingDescription, style: .b1R, color: .gray200)
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -593,10 +593,14 @@ private extension SpotListViewController {
         ) as? T else {
             return UICollectionViewCell()
         }
-
+        var tags: [SpotTagType] = []
         let lockCell = !AuthManager.shared.hasToken && indexPath.item > 4
 
+        if indexPath.item < 5 { tags.append(SpotTagType.top(number: indexPath.item + 1)) }
+        tags.append(contentsOf: spotList.spotList[indexPath.item].tagList)
+
         cell.bind(spot: spotList.spotList[indexPath.item])
+        cell.setTags(tags: tags)
         cell.overlayLoginLock(lockCell)
         cell.setFindCourseDelegate(self)
         cell.isSkeletonable = true

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -442,7 +442,7 @@ extension SpotListViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let spot = viewModel.spotList.spotList[indexPath.item]
         let topTag: SpotTagType? = indexPath.item < 5 ? SpotTagType.top(number: indexPath.item + 1) : nil
-        let vc = SpotDetailViewController(spot.id, topTag)
+        let vc = SpotDetailViewController(spot.spotId, topTag)
 
         if AuthManager.shared.hasToken {
             self.navigationController?.pushViewController(vc, animated: true)
@@ -561,13 +561,13 @@ extension SpotListViewController: SpotListCellDelegate {
                 MapRedirectManager.shared.redirect(
                     to: MapRedirectModel(name: spot.name, latitude: spot.latitude, longitude: spot.longitude),
                     using: .naver)
-                self.viewModel.postGuidedSpot(spotID: spot.id)
+                self.viewModel.postGuidedSpot(spotID: spot.spotId)
             }))
             $0.addAction(UIAlertAction(title: StringLiterals.Map.appleMap, style: .default, handler: { _ in
                 MapRedirectManager.shared.redirect(
                     to: MapRedirectModel(name: spot.name, latitude: spot.latitude, longitude: spot.longitude),
                     using: .apple)
-                self.viewModel.postGuidedSpot(spotID: spot.id)
+                self.viewModel.postGuidedSpot(spotID: spot.spotId)
             }))
             $0.addAction(UIAlertAction(title: StringLiterals.Alert.cancel, style: .cancel, handler: nil))
         }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -440,8 +440,9 @@ extension SpotListViewController: UICollectionViewDataSource {
     // MARK: DidSelectItemAt
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let item = viewModel.spotList.spotList[indexPath.item]
-        let vc = SpotDetailViewController(item.id, item.tagList)
+        let spot = viewModel.spotList.spotList[indexPath.item]
+        let topTag: SpotTagType? = indexPath.item < 5 ? SpotTagType.top(number: indexPath.item + 1) : nil
+        let vc = SpotDetailViewController(spot.id, topTag)
 
         if AuthManager.shared.hasToken {
             self.navigationController?.pushViewController(vc, animated: true)

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
@@ -32,22 +32,6 @@ class SpotListViewModel: Serviceable {
     
     var needToShowToast: ObservablePattern<Bool> = ObservablePattern(nil)
 
-    // TODO: 삭제
-    private let dummyDebouncer = ACDebouncer(delay: 0.5)
-    private var restaurantDummy: [SpotModel] = [
-        SpotModel(id: 1, imageURL: nil, name: "이미지없는 식당", acornCount: 50, tagList: [.new, .local, .top(number: 1)], eta: 1, latitude: 35.785834, longitude: 128.25),
-        SpotModel(id: 2, imageURL: "wrongAddress", name: "이미지에러", acornCount: 50, tagList: [.top(number: 2)], eta: 1, latitude: 35.785834, longitude: 128.25),
-        SpotModel(id: 2, imageURL: "https://cdn.kmecnews.co.kr/news/photo/202311/32217_20955_828.jpg", name: "도토리 완전 많은 뷔페", acornCount: 102938, tagList: [.local, .top(number: 3)], eta: 6, latitude: 35.785834, longitude: 128.25),
-        SpotModel(id: 3, imageURL: "https://images.immediate.co.uk/production/volatile/sites/30/2022/03/Pancake-grazing-board-bc15106.jpg?quality=90&resize=556,505", name: "도토리 없는 팬케익집", acornCount: 0, tagList: [.top(number: 4)], eta: 13, latitude: 35.785834, longitude: 128.25),
-        SpotModel(id: 4, imageURL: "https://natashaskitchen.com/wp-content/uploads/2020/03/Pan-Seared-Steak-4.jpg", name: "영웅스테이크", acornCount: 102938, tagList: [.local, .top(number: 5)], eta: 14, latitude: 35.785834, longitude: 128.25),
-        SpotModel(id: 5, imageURL: "https://i.namu.wiki/i/oFHlYDjoEh8f-cc3lNK9jAemRkbXxNGwUg7XiW5LGS6DF1P2x8GCeNQxbQhVIwtUS1u53YPw-uoyqpmLtrGNJA.webp", name: "아콘삼겹살", acornCount: 1000, tagList: [.new], eta: 6, latitude: 35.785834, longitude: 128.25),
-        SpotModel(id: 6, imageURL: "https://i.namu.wiki/i/dgjXU86ae29hDSCza-L0GZlFt3T9lRx1Ug9cKtqWSzMzs7Cd0CN2SzyLFEJcHVFviKcxAlIwxcllT9s2sck0RA.jpg", name: "아콘비빔밥", acornCount: 3, tagList: [], eta: 6, latitude: 35.785834, longitude: 128.25),
-        SpotModel(id: 6, imageURL: "https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-black-board-background-lunch-dish_1150-42988.jpg?semt=ais_hybrid&w=740", name: "아콘떡볶이", acornCount: 3, tagList: [], eta: 6, latitude: 35.785834, longitude: 128.25),
-        SpotModel(id: 6, imageURL: "https://lh3.googleusercontent.com/proxy/YPQ8wdYuCbfGjedd-TDueWJ3_bnly8lynR3LsrVdSy6BltN3ERoMyzizuUOifkJfbYgaTheo2n8pfacz9jPKCIRrHtrRo9TnBYpGwb2zflw", name: "아콘돈까스이름완전기이이이이이이이이이이이일어", acornCount: 3, tagList: [], eta: 6, latitude: 35.785834, longitude: 128.25),
-        SpotModel(id: 6, imageURL: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSbCQpNp_DERSX-HITj7_CIsqSqic4Mg1Z6GQ&s", name: "아콘떡국", acornCount: 3, tagList: [], eta: 6, latitude: 35.785834, longitude: 128.25),
-        SpotModel(id: 6, imageURL: "https://sm.ign.com/ign_kr/game/k/kirby-and-/kirby-and-the-forgotten-land_pk1v.jpg", name: "팟팅커비~!~!~!", acornCount: 3, tagList: [], eta: 6, latitude: 35.785834, longitude: 128.25)
-    ]
-
 
     // MARK: - Filter
 
@@ -76,72 +60,48 @@ class SpotListViewModel: Serviceable {
 extension SpotListViewModel {
 
     func postSpotList() {
-        // TODO: - 주석 해제 (실제 로직)
-        // self.spotList = SpotListModel(
-        //     transportMode: self.spotType == .restaurant ? .walking : .biking,
-        //     spotList: self.restaurantDummy
-        // )
-        // self.onSuccessPostSpotList.value = true
-        // self.lastNetworkLocation = userLocation
-
-        // TODO: - 삭제 (테스트용)
-        dummyDebouncer.call {
-            self.spotList = SpotListModel(
-                transportMode: self.spotType == .restaurant ? .walking : .biking,
-                spotList: self.restaurantDummy
-            )
-            self.onSuccessPostSpotList.value = true
-            return
+        let filterListDTO = filterList.map { filter in
+            return SpotFilterDTO(category: filter.category.serverKey,
+                                       optionList: filter.optionList)
         }
-        self.lastNetworkLocation = CLLocation(latitude: 37.0, longitude: 127.00)
-        
-        return
 
-        // TODO: 주석해제
-//        let filterListDTO = filterList.map { filter in
-//            return SpotFilterDTO(category: filter.category.serverKey,
-//                                       optionList: filter.optionList)
-//        }
-//        
-//        let requestBody = PostSpotListRequest(
-//            latitude: userCoordinate.latitude,
-//            longitude: userCoordinate.longitude,
-//            condition: SpotConditionDTO(
-//                spotType: spotType.serverKey,
-//                filterList: filterList.isEmpty ? nil : filterListDTO
-//            )
-//        )
+        let requestBody = PostSpotListRequest(
+            latitude: userCoordinate.latitude,
+            longitude: userCoordinate.longitude,
+            condition: SpotConditionDTO(
+                spotType: spotType.serverKey,
+                filterList: filterList.isEmpty ? nil : filterListDTO
+            )
+        )
 
-//        ACService.shared.spotListService.postSpotList(requestBody: requestBody) { [weak self] response in
-//            switch response {
-//            case .success(let data):
-//                let spotList: SpotListModel = SpotListModel(from: data)
-//
-//                self?.spotList = spotList
-//
-//                if spotList.spotList.isEmpty { self?.errorType = .emptyList }
-//                self?.onSuccessPostSpotList.value = true
-//
-//            case .reIssueJWT:
-//                self?.handleReissue { [weak self] in
-//                    self?.postSpotList()
-//                }
-//
-//            case .requestErr(let error):
-//                print("🥑post spotList requestErr: \(error)")
-//                if error.code == 40405 {
-//                    self?.errorType = .unsupportedRegion
-//                } else {
-//                    self?.errorType = .serverRequestFail // TODO: 에러 뷰 또는 Alert 띄우기
-//                }
-//                self?.onSuccessPostSpotList.value = false
-//
-//            default:
-//                print("🥑Failed To Post")
-//                self?.onSuccessPostSpotList.value = false
-//                return
-//            }
-//        }
+        ACService.shared.spotListService.postSpotList(requestBody: requestBody) { [weak self] response in
+            switch response {
+            case .success(let data):
+                let spotList: SpotListModel = SpotListModel(from: data)
+
+                self?.spotList = spotList
+
+                if spotList.spotList.isEmpty { self?.errorType = .emptyList }
+                self?.onSuccessPostSpotList.value = true
+
+            case .reIssueJWT:
+                self?.handleReissue { [weak self] in
+                    self?.postSpotList()
+                }
+
+            case .requestErr(let error):
+                if error.code == 40405 {
+                    self?.errorType = .unsupportedRegion
+                } else {
+                    self?.errorType = .serverRequestFail // TODO: 에러 뷰 또는 Alert 띄우기
+                }
+                self?.onSuccessPostSpotList.value = false
+
+            default:
+                self?.onSuccessPostSpotList.value = false
+                return
+            }
+        }
     }
 
     func postGuidedSpot(spotID: Int64) {


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #194 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
- **홈, 장소 상세 API 연결**
  - POST 위치 기반 장소 추천
  - POST 최근 길 안내 장소 저장
  - POST, DELETE 장소 북마크
  - GET 장소 상세 정보 조회

- **버그 해결 및 주요 수정사항**
  - life cycle 문제로 무한 스켈레톤 되는 문제 해결
  - 메뉴판 contentMode scaleAspectFill -> scaleAspectFit으로 수정
  - 장소 상세의 side 버튼에 UITapGesture를 2개 이상 등록하니
  먼저 등록한 제스쳐 액션이 작동하지 않는 문제를 발견
  -> 기본 TapGesture는 isSelected 상태 변경 로직 유지
  -> 추가 액션은 onTap 클로저로 대체



## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰 16 Pro|<img src = "https://github.com/user-attachments/assets/f5e598b2-30c5-4574-8582-d889a7b7d73b" width ="250">|


## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #194 
