### PR TITLE
[FEAT] 2.1.0 지역인증 UI 및 지역인증 리마인더 바텀시트 (#229)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		746FF3C02D3D8669001CDAAC /* ACWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */; };
 		74721B4B2E2A07D100F0ACB9 /* SemiShortModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74721B4A2E2A07D100F0ACB9 /* SemiShortModalView.swift */; };
 		74721B4E2E2A08DC00F0ACB9 /* SemiShortModalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74721B4D2E2A08CE00F0ACB9 /* SemiShortModalType.swift */; };
+		74721B502E2A0F9A00F0ACB9 /* VerificationReminderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74721B4F2E2A0F7D00F0ACB9 /* VerificationReminderViewController.swift */; };
 		74770C192DF1DA97005D4165 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 74770C182DF1DA97005D4165 /* GoogleMobileAds */; };
 		74770C1B2DF35848005D4165 /* ProfileGoogleAdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74770C1A2DF35848005D4165 /* ProfileGoogleAdView.swift */; };
 		74770C1D2DF36DAB005D4165 /* GoogleAdsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74770C1C2DF36DA2005D4165 /* GoogleAdsType.swift */; };
@@ -499,6 +500,7 @@
 		746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACWebViewController.swift; sourceTree = "<group>"; };
 		74721B4A2E2A07D100F0ACB9 /* SemiShortModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemiShortModalView.swift; sourceTree = "<group>"; };
 		74721B4D2E2A08CE00F0ACB9 /* SemiShortModalType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemiShortModalType.swift; sourceTree = "<group>"; };
+		74721B4F2E2A0F7D00F0ACB9 /* VerificationReminderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationReminderViewController.swift; sourceTree = "<group>"; };
 		74770C1A2DF35848005D4165 /* ProfileGoogleAdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileGoogleAdView.swift; sourceTree = "<group>"; };
 		74770C1C2DF36DA2005D4165 /* GoogleAdsType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsType.swift; sourceTree = "<group>"; };
 		747BB6CD2DCA66EB00352874 /* GlassButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassButtonState.swift; sourceTree = "<group>"; };
@@ -2238,6 +2240,7 @@
 				74A13D6B2DCC035F007FFFC3 /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
 				746F15B72D3E2083003EA031 /* PostLocalAreaRequest.swift in Sources */,
 				74BF92142D391FFE00B923E3 /* LocalMapView.swift in Sources */,
+				74721B502E2A0F9A00F0ACB9 /* VerificationReminderViewController.swift in Sources */,
 				D696F1B22D3A7E3400CCD5FF /* ACAlertView.swift in Sources */,
 				743069892D3D2F5A0033178C /* NetworkResult.swift in Sources */,
 				152F8D242DF268FA0064022B /* SpotListCellDelegate.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -203,6 +203,8 @@
 		746F5BF02DE009820081569B /* ACToastType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746F5BEF2DE0097B0081569B /* ACToastType.swift */; };
 		746F5BF22DE00CE90081569B /* GlassBorderAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746F5BF12DE00CE90081569B /* GlassBorderAttributes.swift */; };
 		746FF3C02D3D8669001CDAAC /* ACWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */; };
+		74721B4B2E2A07D100F0ACB9 /* SemiShortModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74721B4A2E2A07D100F0ACB9 /* SemiShortModalView.swift */; };
+		74721B4E2E2A08DC00F0ACB9 /* SemiShortModalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74721B4D2E2A08CE00F0ACB9 /* SemiShortModalType.swift */; };
 		74770C192DF1DA97005D4165 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 74770C182DF1DA97005D4165 /* GoogleMobileAds */; };
 		74770C1B2DF35848005D4165 /* ProfileGoogleAdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74770C1A2DF35848005D4165 /* ProfileGoogleAdView.swift */; };
 		74770C1D2DF36DAB005D4165 /* GoogleAdsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74770C1C2DF36DA2005D4165 /* GoogleAdsType.swift */; };
@@ -289,7 +291,6 @@
 		74FA77842DD43709006846C9 /* SplashBGM.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 74FA77832DD43709006846C9 /* SplashBGM.mp3 */; };
 		D652597C2D62775C00B8176E /* CustomTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D652597B2D62775C00B8176E /* CustomTextFieldView.swift */; };
 		D652597E2D628EB000B8176E /* WithdrawalConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D652597D2D628EB000B8176E /* WithdrawalConfirmationViewController.swift */; };
-		D65259802D6291A800B8176E /* WithdrawalConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D652597F2D6291A800B8176E /* WithdrawalConfirmationView.swift */; };
 		D696F1B22D3A7E3400CCD5FF /* ACAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D696F1B12D3A7E3400CCD5FF /* ACAlertView.swift */; };
 		D6E34C462D398B6000CEFA04 /* ACAlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E34C3D2D398B6000CEFA04 /* ACAlertType.swift */; };
 		D6E34C472D398B6000CEFA04 /* ACAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E34C3E2D398B6000CEFA04 /* ACAlertViewController.swift */; };
@@ -496,6 +497,8 @@
 		746F5BEF2DE0097B0081569B /* ACToastType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACToastType.swift; sourceTree = "<group>"; };
 		746F5BF12DE00CE90081569B /* GlassBorderAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassBorderAttributes.swift; sourceTree = "<group>"; };
 		746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACWebViewController.swift; sourceTree = "<group>"; };
+		74721B4A2E2A07D100F0ACB9 /* SemiShortModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemiShortModalView.swift; sourceTree = "<group>"; };
+		74721B4D2E2A08CE00F0ACB9 /* SemiShortModalType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemiShortModalType.swift; sourceTree = "<group>"; };
 		74770C1A2DF35848005D4165 /* ProfileGoogleAdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileGoogleAdView.swift; sourceTree = "<group>"; };
 		74770C1C2DF36DA2005D4165 /* GoogleAdsType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsType.swift; sourceTree = "<group>"; };
 		747BB6CD2DCA66EB00352874 /* GlassButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassButtonState.swift; sourceTree = "<group>"; };
@@ -580,7 +583,6 @@
 		BB785B4E26FA7C11BB85A55D /* Pods-ACON-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ACON-iOS.debug.xcconfig"; path = "Target Support Files/Pods-ACON-iOS/Pods-ACON-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		D652597B2D62775C00B8176E /* CustomTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextFieldView.swift; sourceTree = "<group>"; };
 		D652597D2D628EB000B8176E /* WithdrawalConfirmationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalConfirmationViewController.swift; sourceTree = "<group>"; };
-		D652597F2D6291A800B8176E /* WithdrawalConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalConfirmationView.swift; sourceTree = "<group>"; };
 		D696F1B12D3A7E3400CCD5FF /* ACAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACAlertView.swift; sourceTree = "<group>"; };
 		D6E34C3D2D398B6000CEFA04 /* ACAlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACAlertType.swift; sourceTree = "<group>"; };
 		D6E34C3E2D398B6000CEFA04 /* ACAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACAlertViewController.swift; sourceTree = "<group>"; };
@@ -1303,6 +1305,15 @@
 			path = Type;
 			sourceTree = "<group>";
 		};
+		74721B4C2E2A089800F0ACB9 /* SemiShortModal */ = {
+			isa = PBXGroup;
+			children = (
+				74721B4D2E2A08CE00F0ACB9 /* SemiShortModalType.swift */,
+				74721B4A2E2A07D100F0ACB9 /* SemiShortModalView.swift */,
+			);
+			path = SemiShortModal;
+			sourceTree = "<group>";
+		};
 		747F4FB82D3D944A003DECBF /* Splash */ = {
 			isa = PBXGroup;
 			children = (
@@ -1469,6 +1480,7 @@
 		748D6F7A2D2BCCF4007690B4 /* UIComponents */ = {
 			isa = PBXGroup;
 			children = (
+				74721B4C2E2A089800F0ACB9 /* SemiShortModal */,
 				742B1B972E00AE300036876A /* NetworkErrorView.swift */,
 				746F5BEA2DE0091B0081569B /* ACToast */,
 				74A13D6A2DCC035F007FFFC3 /* LeftAlignedCollectionViewFlowLayout.swift */,
@@ -1664,6 +1676,7 @@
 				74BF920D2D391FFE00B923E3 /* LocalVerificationViewController.swift */,
 				151BD9522D6332A5005E657F /* VerifiedAreasEditView.swift */,
 				151BD9542D63375D005E657F /* VerifiedAreasEditViewController.swift */,
+				74721B4F2E2A0F7D00F0ACB9 /* VerificationReminderViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1844,7 +1857,6 @@
 			children = (
 				D6E8168D2D6228F5001E4EBF /* WithdrawalViewController.swift */,
 				D652597D2D628EB000B8176E /* WithdrawalConfirmationViewController.swift */,
-				D652597F2D6291A800B8176E /* WithdrawalConfirmationView.swift */,
 				D6E816A42D623FE5001E4EBF /* WithdrawalTableView.swift */,
 				D652597B2D62775C00B8176E /* CustomTextFieldView.swift */,
 				D6E816A32D623E11001E4EBF /* Cell */,
@@ -2099,7 +2111,6 @@
 				D652597E2D628EB000B8176E /* WithdrawalConfirmationViewController.swift in Sources */,
 				746FF3C02D3D8669001CDAAC /* ACWebViewController.swift in Sources */,
 				152F8D202DF253FE0064022B /* AppleMapService.swift in Sources */,
-				D65259802D6291A800B8176E /* WithdrawalConfirmationView.swift in Sources */,
 				155D45B82E26CCBC008C0316 /* BaseUploadInquiryViewController.swift in Sources */,
 				741A06C82D3532E500778219 /* DropAcornView.swift in Sources */,
 				15D122292D58BD0200E79866 /* DayOfMonthType.swift in Sources */,
@@ -2162,6 +2173,7 @@
 				748ECA6B2D31918D00BBC981 /* LoginView.swift in Sources */,
 				D6EA38152D42B88F002B68B9 /* SearchEmptyView.swift in Sources */,
 				74D31C712D5832D000B4B2B4 /* AlbumViewModel.swift in Sources */,
+				74721B4B2E2A07D100F0ACB9 /* SemiShortModalView.swift in Sources */,
 				1503DBEB2DFD9CBB001FC3E5 /* GetMenuboardImageListResponse.swift in Sources */,
 				746A13B82E00549E0097DA25 /* OnboardingTargetType.swift in Sources */,
 				1547A6F22D33AD4500E96616 /* SpotListModel.swift in Sources */,
@@ -2290,6 +2302,7 @@
 				15AA6D172D68B4EF008021C6 /* SpotListErrorType.swift in Sources */,
 				741E68952D3D38BC00DF99EF /* BaseService.swift in Sources */,
 				746F15BB2D3E2167003EA031 /* LocalVerificationTargetType.swift in Sources */,
+				74721B4E2E2A08DC00F0ACB9 /* SemiShortModalType.swift in Sources */,
 				D6E34C462D398B6000CEFA04 /* ACAlertType.swift in Sources */,
 				D6E34C472D398B6000CEFA04 /* ACAlertViewController.swift in Sources */,
 				745C7E022D358E900074DBDB /* SpotSearchView.swift in Sources */,

--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -278,6 +278,18 @@ enum StringLiterals {
         
     }
     
+    enum LocalVerificationModal {
+        
+        static let title = "내 지역을 인증해 주세요!"
+        
+        static let description = "내 지역에 남긴 리뷰는 로컬리뷰로 인정되어\n더 많은 사람들에게 추천돼요."
+        
+        static let cancel = "다음에 하기"
+        
+        static let confirm = "지역 인증하러 하기"
+        
+    }
+    
     enum SpotListFilter {
         
         static let pageTitle = "상세조건"

--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -244,9 +244,11 @@ enum StringLiterals {
     
     enum LocalVerification {
         
+        static let warning = "현재 내 지역에 안 계시면 건너뛰기를 해주세요"
+        
         static let title = "믿을 수 있는 리뷰를 위해\n지역인증이 필요해요"
         
-        static let description = "더 정확한 로컬맛집을 추천해드릴 수 있어요"
+        static let description = "내 지역에 남긴 리뷰는 추천 장소에 반영돼요."
         
         static let oneSecond = "1초만에 인증하기"
         

--- a/ACON-iOS/ACON-iOS/Global/UIComponents/LoginModal/View/LoginModalViewController.swift
+++ b/ACON-iOS/ACON-iOS/Global/UIComponents/LoginModal/View/LoginModalViewController.swift
@@ -128,13 +128,13 @@ extension LoginModalViewController {
                 if hasVerifiedArea {
                     let authStatus = ACLocationManager.shared.locationManager.authorizationStatus
                     if authStatus == .denied || authStatus == .restricted {
-                        navigateToLocalVerificationVC()
+                        NavigationUtils.navigateToOnboardingLocalVerification()
                     } else {
                         NavigationUtils.navigateToTabBar()
                     }
                 } else {
                     print("🥑onSuccess && !hasVerifiedArea")
-                    navigateToLocalVerificationVC()
+                    NavigationUtils.navigateToOnboardingLocalVerification()
                 }
                 if let presentedVCType = presentedVCType {
                     AmplitudeManager.shared.trackEventWithProperties(AmplitudeLiterals.EventName.guest, properties: [presentedVCType: true])
@@ -142,14 +142,6 @@ extension LoginModalViewController {
             } else {
                 showLoginFailAlert()
             }
-        }
-    }
-
-    func navigateToLocalVerificationVC() {
-        let vm = LocalVerificationViewModel(flowType: .onboarding)
-        let vc = LocalVerificationViewController(viewModel: vm)
-        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
-            sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: vc)
         }
     }
     

--- a/ACON-iOS/ACON-iOS/Global/UIComponents/SemiShortModal/SemiShortModalType.swift
+++ b/ACON-iOS/ACON-iOS/Global/UIComponents/SemiShortModal/SemiShortModalType.swift
@@ -1,0 +1,51 @@
+//
+//  SemiShortModalType.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 7/18/25.
+//
+
+import Foundation
+
+enum SemiShortModalType: CaseIterable {
+    
+    case localVerificationReminder
+    case withdrawalConfirmation
+    
+    var title: String {
+        switch self {
+        case .localVerificationReminder:
+            return StringLiterals.LocalVerificationModal.title
+        case .withdrawalConfirmation:
+            return StringLiterals.WithdrawalConfirmation.title
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .localVerificationReminder:
+            return StringLiterals.LocalVerificationModal.description
+        case .withdrawalConfirmation:
+            return StringLiterals.WithdrawalConfirmation.description
+        }
+    }
+    
+    var cancelButtonTitle: String {
+        switch self {
+        case .localVerificationReminder:
+            return StringLiterals.LocalVerificationModal.cancel
+        case .withdrawalConfirmation:
+            return StringLiterals.WithdrawalConfirmation.cancelButtonTitle
+        }
+    }
+    
+    var confirmButtonTitle: String {
+        switch self {
+        case .localVerificationReminder:
+            return StringLiterals.LocalVerificationModal.confirm
+        case .withdrawalConfirmation:
+            return StringLiterals.WithdrawalConfirmation.confirmButtonTitle
+        }
+    }
+    
+}

--- a/ACON-iOS/ACON-iOS/Global/UIComponents/SemiShortModal/SemiShortModalView.swift
+++ b/ACON-iOS/ACON-iOS/Global/UIComponents/SemiShortModal/SemiShortModalView.swift
@@ -2,12 +2,12 @@
 //  WithdrawalConfirmationView.swift
 //  ACON-iOS
 //
-//  Created by Jaehyun Ahn on 2/17/25.
+//  Created by 이수민 on 7/18/25.
 //
 
 import UIKit
 
-final class WithdrawalConfirmationView: GlassmorphismView {
+final class SemiShortModalView: GlassmorphismView {
     
     // MARK: - UI Properties
     
@@ -15,38 +15,26 @@ final class WithdrawalConfirmationView: GlassmorphismView {
     
     private let descriptionLabel = UILabel()
     
-    let cancelButton = ACButton(style: GlassButton(borderGlassmorphismType: .buttonGlassDefault, buttonType: .line_22_b1SB), title: StringLiterals.WithdrawalConfirmation.cancelButtonTitle)
+    let cancelButton: ACButton
 
-    let confirmButton = ACButton(style: GlassButton(glassmorphismType: .buttonGlassDefault, buttonType: .full_22_b1SB), title: StringLiterals.WithdrawalConfirmation.confirmButtonTitle)
+    let confirmButton: ACButton
+    
+    private let semiShortModalType: SemiShortModalType
     
     
     // MARK: - LifeCycle
     
-    init() {
+    init(semiShortModalType: SemiShortModalType) {
+        self.semiShortModalType = semiShortModalType
+        
+        self.cancelButton = ACButton(style: GlassButton(borderGlassmorphismType: .buttonGlassDefault, buttonType: .line_22_b1SB), title: semiShortModalType.cancelButtonTitle)
+        self.confirmButton = ACButton(style: GlassButton(glassmorphismType: .buttonGlassDefault, buttonType: .full_22_b1SB), title: semiShortModalType.confirmButtonTitle)
+        
         super.init(.bottomSheetGlass)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func setStyle() {
-        super.setStyle()
-        
-        self.setHandlerImageView()
-
-        titleLabel.setLabel(text: StringLiterals.WithdrawalConfirmation.title,
-                            style: .h4SB,
-                            alignment: .center)
-        
-        descriptionLabel.setLabel(text: StringLiterals.WithdrawalConfirmation.description,
-                                  style: .b1R,
-                                  color: .gray300,
-                                  alignment: .center)
-        
-        [cancelButton, confirmButton].forEach {
-            $0.isUserInteractionEnabled = true
-        }
     }
     
     override func setHierarchy() {
@@ -86,4 +74,19 @@ final class WithdrawalConfirmationView: GlassmorphismView {
         }
     }
 
+    override func setStyle() {
+        super.setStyle()
+        
+        self.setHandlerImageView()
+
+        titleLabel.setLabel(text: semiShortModalType.title,
+                            style: .h4SB,
+                            alignment: .center)
+        
+        descriptionLabel.setLabel(text: semiShortModalType.description,
+                                  style: .b1R,
+                                  color: .gray300,
+                                  alignment: .center)
+    }
+    
 }

--- a/ACON-iOS/ACON-iOS/Global/UIComponents/SemiShortModal/SemiShortModalView.swift
+++ b/ACON-iOS/ACON-iOS/Global/UIComponents/SemiShortModal/SemiShortModalView.swift
@@ -63,14 +63,14 @@ final class SemiShortModalView: GlassmorphismView {
             $0.top.equalToSuperview().inset(219*ScreenUtils.heightRatio)
             $0.leading.equalToSuperview().inset(ScreenUtils.horizontalInset)
             $0.width.equalTo(ScreenUtils.widthRatio*120)
-            $0.height.equalTo(ScreenUtils.heightRatio*44)
+            $0.height.equalTo(44)
         }
         
         confirmButton.snp.makeConstraints{
             $0.top.equalToSuperview().inset(219*ScreenUtils.heightRatio)
             $0.trailing.equalToSuperview().inset(ScreenUtils.horizontalInset)
             $0.width.equalTo(ScreenUtils.widthRatio*200)
-            $0.height.equalTo(ScreenUtils.heightRatio*44)
+            $0.height.equalTo(44)
         }
     }
 

--- a/ACON-iOS/ACON-iOS/Global/Utils/NavigatonUtils.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/NavigatonUtils.swift
@@ -41,4 +41,10 @@ struct NavigationUtils {
         }
     }
     
+    static func naviateToLoginOnboarding() {
+        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+            sceneDelegate.window?.rootViewController = OnboardingViewController(flowType: .login)
+        }
+    }
+    
 }

--- a/ACON-iOS/ACON-iOS/Global/Utils/NavigatonUtils.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/NavigatonUtils.swift
@@ -33,4 +33,12 @@ struct NavigationUtils {
         }
     }
     
+    static func navigateToOnboardingLocalVerification() {
+        let vm = LocalVerificationViewModel(flowType: .onboarding)
+        let vc = LocalVerificationViewController(viewModel: vm)
+        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+            sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: vc)
+        }
+    }
+    
 }

--- a/ACON-iOS/ACON-iOS/Global/Utils/ScreenUtils.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/ScreenUtils.swift
@@ -50,6 +50,13 @@ struct ScreenUtils {
         return window.safeAreaInsets.top
     }
 
+    static var safeAreaBottomHeight: CGFloat {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = windowScene.windows.first else {
+            return 0
+        }
+        return window.safeAreaInsets.bottom
+    }
     
     // MARK: - horizontal inset
     

--- a/ACON-iOS/ACON-iOS/Presentation/Base/BaseNavViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Base/BaseNavViewController.swift
@@ -36,6 +36,8 @@ class BaseNavViewController: UIViewController {
     
     var backCompletion: (() -> Void)?
     
+    var skipCompletion: (() -> Void)?
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -222,8 +224,7 @@ extension BaseNavViewController {
     
     
     // MARK: - 건너뛰기 버튼
-    
-    func setSkipButton() {
+    func setSkipButton(completion: (() -> Void)? = NavigationUtils.navigateToTabBar) {
         rightButton.do {
             $0.isHidden = false
             $0.setAttributedTitle(text: "건너뛰기", style: .t4SB)
@@ -231,11 +232,12 @@ extension BaseNavViewController {
                             target: self,
                             action: #selector(skipButtonTapped))
         }
+        self.skipCompletion = completion
     }
-    
+
     @objc
     func skipButtonTapped() {
-        NavigationUtils.navigateToTabBar()
+        skipCompletion?()
     }
     
     

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalMapView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalMapView.swift
@@ -42,7 +42,7 @@ final class LocalMapView: BaseView {
         
         finishVerificationButton.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(ScreenUtils.heightRatio*36)
-            $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.widthRatio*20)
+            $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.horizontalInset)
             $0.height.equalTo(52)
         }
         
@@ -62,8 +62,8 @@ final class LocalMapView: BaseView {
                 $0.minZoomLevel = 14
                 $0.maxZoomLevel = 18
                 $0.customStyleId = Config.nmfCustomStyleID
-                $0.logoAlign = .rightTop
-                $0.logoMargin = ConstraintInsets(top: ScreenUtils.safeAreaTopHeight+ScreenUtils.heightRatio*80, left: 0, bottom: 0, right: ScreenUtils.horizontalInset)
+                $0.logoAlign = .leftBottom
+                $0.logoMargin = ConstraintInsets(top: 0, left: ScreenUtils.horizontalInset, bottom: ScreenUtils.heightRatio*66, right: 0)
             }
         }
 

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationView.swift
@@ -13,7 +13,7 @@ final class LocalVerificationView: BaseView {
     
     private let backgroundImageView: UIImageView = UIImageView()
     
-    private let warningLabel: UILabel = UILabel()
+    let warningLabel: UILabel = UILabel()
     
     private let titleLabel: UILabel = UILabel()
     

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationView.swift
@@ -7,9 +7,6 @@
 
 import UIKit
 
-import SnapKit
-import Then
-
 final class LocalVerificationView: BaseView {
 
     // MARK: - UI Properties
@@ -21,8 +18,6 @@ final class LocalVerificationView: BaseView {
     private let titleLabel: UILabel = UILabel()
     
     private let descriptionLabel: UILabel = UILabel()
-    
-    private let oneSecondLabel: UILabel = UILabel()
     
     var nextButton: ACButton = ACButton(style: GlassButton(glassmorphismType: .buttonGlassDefault, buttonType: .full_12_t4SB), title: StringLiterals.LocalVerification.next)
     
@@ -36,7 +31,6 @@ final class LocalVerificationView: BaseView {
                          warningLabel,
                          titleLabel,
                          descriptionLabel,
-                         oneSecondLabel,
                          nextButton)
     }
     
@@ -66,13 +60,7 @@ final class LocalVerificationView: BaseView {
             $0.centerX.equalToSuperview()
             $0.height.equalTo(20)
         }
-        
-        oneSecondLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(ScreenUtils.heightRatio*559)
-            $0.centerX.equalToSuperview()
-            $0.height.equalTo(20)
-        }
-        
+
         nextButton.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(21+ScreenUtils.heightRatio*16)
             $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.horizontalInset)
@@ -107,11 +95,6 @@ final class LocalVerificationView: BaseView {
                         color: .gray50)
         }
         
-        oneSecondLabel.do {
-            $0.setLabel(text: StringLiterals.LocalVerification.oneSecond,
-                        style: .b1R,
-                        color: .gray500)
-        }
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationView.swift
@@ -16,6 +16,8 @@ final class LocalVerificationView: BaseView {
     
     private let backgroundImageView: UIImageView = UIImageView()
     
+    private let warningLabel: UILabel = UILabel()
+    
     private let titleLabel: UILabel = UILabel()
     
     private let descriptionLabel: UILabel = UILabel()
@@ -31,6 +33,7 @@ final class LocalVerificationView: BaseView {
         super.setHierarchy()
         
         self.addSubviews(backgroundImageView,
+                         warningLabel,
                          titleLabel,
                          descriptionLabel,
                          oneSecondLabel,
@@ -43,23 +46,29 @@ final class LocalVerificationView: BaseView {
         backgroundImageView.snp.makeConstraints {
             $0.size.equalTo(ScreenUtils.heightRatio*480)
             $0.centerX.equalToSuperview()
-            $0.top.equalToSuperview().inset(ScreenUtils.heightRatio*256)
+            $0.top.equalToSuperview().inset(ScreenUtils.heightRatio*252)
+        }
+        
+        warningLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(ScreenUtils.heightRatio*67)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(20)
         }
         
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(ScreenUtils.heightRatio*455)
+            $0.top.equalToSuperview().inset(ScreenUtils.heightRatio*401)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(68)
         }
         
         descriptionLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(ScreenUtils.heightRatio*535)
+            $0.top.equalToSuperview().inset(ScreenUtils.heightRatio*481)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(20)
         }
         
         oneSecondLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(ScreenUtils.heightRatio*613)
+            $0.top.equalToSuperview().inset(ScreenUtils.heightRatio*559)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(20)
         }
@@ -77,6 +86,13 @@ final class LocalVerificationView: BaseView {
         
         backgroundImageView.do {
             $0.image = .imgBackgroundLocalCertification
+        }
+        
+        warningLabel.do {
+            $0.setLabel(text: StringLiterals.LocalVerification.warning,
+                        style: .b1R,
+                        color: .gray500,
+                        alignment: .center)
         }
         
         titleLabel.do {

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class LocalVerificationViewController: BaseViewController {
+class LocalVerificationViewController: BaseNavViewController {
     
     // MARK: - UI Properties
     
@@ -35,6 +35,7 @@ class LocalVerificationViewController: BaseViewController {
         
         addTarget()
         bindViewModel()
+        self.setSkipButton()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -46,7 +47,7 @@ class LocalVerificationViewController: BaseViewController {
     override func setHierarchy() {
         super.setHierarchy()
         
-        self.view.addSubview(localVerificationView)
+        self.contentView.addSubview(localVerificationView)
     }
     
     override func setLayout() {

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
@@ -7,9 +7,6 @@
 
 import UIKit
 
-import SnapKit
-import Then
-
 class LocalVerificationViewController: BaseNavViewController {
     
     // MARK: - UI Properties

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
@@ -39,6 +39,9 @@ class LocalVerificationViewController: BaseNavViewController {
         addTarget()
         bindViewModel()
         self.setSkipButton() {
+            let now = Date()
+            UserDefaults.standard.set(now, forKey: "lastLocalVerificationAlertTime")
+            
             NavigationUtils.naviateToLoginOnboarding()
         }
     }

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
@@ -76,17 +76,8 @@ private extension LocalVerificationViewController {
                 if localVerificationViewModel.isLocationKorea {
                     pushToLocalMapVC()
                 } else {
-                    switch localVerificationViewModel.flowType {
-                    case .onboarding:
-                        self.showDefaultAlert(title: "알림", message: "현재 동네인증이 불가능한 지역에 있어요", okText: "온보딩으로 이동", completion: {
-                            if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
-                                sceneDelegate.window?.rootViewController = OnboardingViewController(flowType: .login)
-                            }
-                        })
-                    default:
-                        self.showDefaultAlert(title: "알림", message: "현재 동네인증이 불가능한 지역에 있어요", okText: "홈으로 이동", completion: {
-                            NavigationUtils.navigateToTabBar()})
-                    }
+                    self.showDefaultAlert(title: "알림", message: "현재 지역인증이 불가능한 지역에 있어요", okText: "홈으로 이동", completion: {
+                        NavigationUtils.navigateToTabBar()})
                 }
             } else {
                 self.showDefaultAlert(title: "위치 확인 실패", message: "위치를 확인할 수 없습니다.")

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
@@ -38,7 +38,9 @@ class LocalVerificationViewController: BaseNavViewController {
         
         addTarget()
         bindViewModel()
-        self.setSkipButton()
+        self.setSkipButton() {
+            NavigationUtils.naviateToLoginOnboarding()
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -83,8 +85,12 @@ private extension LocalVerificationViewController {
                 if localVerificationViewModel.isLocationKorea {
                     pushToLocalMapVC()
                 } else {
-                    self.showDefaultAlert(title: "알림", message: "현재 지역인증이 불가능한 지역에 있어요", okText: "홈으로 이동", completion: {
-                        NavigationUtils.navigateToTabBar()})
+                    switch localVerificationViewModel.flowType {
+                    case .onboarding:
+                        self.showDefaultAlert(title: "알림", message: "현재 동네인증이 불가능한 지역에 있어요", okText: "온보딩으로 이동", completion: {NavigationUtils.naviateToLoginOnboarding()})
+                    default:
+                        self.showDefaultAlert(title: "알림", message: "현재 동네인증이 불가능한 지역에 있어요", okText: "홈으로 이동", completion: {NavigationUtils.navigateToTabBar()})
+                    }
                 }
             } else {
                 self.showDefaultAlert(title: "위치 확인 실패", message: "위치를 확인할 수 없습니다.")

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
@@ -15,7 +15,9 @@ class LocalVerificationViewController: BaseNavViewController {
     
     private let localVerificationViewModel: LocalVerificationViewModel
     
-    
+    private var blinkTimer: Timer?
+
+
     // MARK: - LifeCycle
     
     init(viewModel: LocalVerificationViewModel) {
@@ -25,6 +27,10 @@ class LocalVerificationViewController: BaseNavViewController {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        stopBlinkingWarningLabel()
     }
     
     override func viewDidLoad() {
@@ -39,6 +45,7 @@ class LocalVerificationViewController: BaseNavViewController {
         super.viewWillAppear(false)
 
         self.tabBarController?.tabBar.isHidden = true
+        startBlinkingWarningLabel()
     }
     
     override func setHierarchy() {
@@ -108,6 +115,29 @@ extension LocalVerificationViewController {
     func pushToLocalMapVC() {
         let vc = LocalMapViewController(viewModel: localVerificationViewModel)
         navigationController?.pushViewController(vc, animated: false)
+    }
+    
+}
+
+
+// MARK: - Warning Label Blinking Logic
+
+private extension LocalVerificationViewController {
+
+    func startBlinkingWarningLabel() {
+        stopBlinkingWarningLabel()
+        
+        blinkTimer = Timer.scheduledTimer(withTimeInterval: 0.6, repeats: true) { _ in
+            UIView.animate(withDuration: 0.3) {
+                self.localVerificationView.warningLabel.alpha = self.localVerificationView.warningLabel.alpha == 1.0 ? 0.0 : 1.0
+            }
+        }
+    }
+
+    func stopBlinkingWarningLabel() {
+        blinkTimer?.invalidate()
+        blinkTimer = nil
+        localVerificationView.warningLabel.alpha = 1.0
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/VerificationReminderViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/VerificationReminderViewController.swift
@@ -1,0 +1,50 @@
+//
+//  VerificationReminderViewController.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 7/18/25.
+//
+
+import UIKit
+
+final class VerificationReminderViewController: BaseViewController {
+    
+    private let modalView = SemiShortModalView(semiShortModalType: .localVerificationReminder)
+    
+    private var viewModel = LocalVerificationViewModel(flowType: .setting)
+    
+    override func loadView() {
+        view = modalView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setAction()
+    }
+    
+}
+
+
+// MARK: - setAction
+
+private extension VerificationReminderViewController {
+    
+    func setAction() {
+        modalView.cancelButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
+        modalView.confirmButton.addTarget(self, action: #selector(confirmButtonTapped), for: .touchUpInside)
+    }
+    
+    @objc
+    func cancelButtonTapped() {
+        let now = Date()
+        UserDefaults.standard.set(now, forKey: "lastLocalVerificationAlertTime")
+        dismiss(animated: true)
+    }
+    
+    @objc
+    func confirmButtonTapped() {
+        NavigationUtils.navigateToOnboardingLocalVerification()
+    }
+    
+}

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -45,6 +45,7 @@ class SpotListViewController: BaseNavViewController {
         super.viewWillAppear(false)
 
         self.tabBarController?.tabBar.isHidden = false
+        presentVerificationReminderSheet()
         viewModel.startLocationTracking()
     }
 
@@ -747,6 +748,36 @@ private extension SpotListViewController {
     func appDidEnterBackground() {
         viewModel.stopLocationTracking()
         hideLocationCheckToast()
+    }
+    
+}
+
+
+// MARK: - 지역 인증 바텀시트
+
+private extension SpotListViewController {
+    
+    func presentVerificationReminderSheet() {
+        guard AuthManager.shared.hasToken else { return }
+        guard !AuthManager.shared.hasVerifiedArea else { return }
+        
+        let lastAlertTime = UserDefaults.standard.object(forKey: "lastLocalVerificationAlertTime") as? Date
+        let now = Date()
+        
+        if let lastTime = lastAlertTime {
+            let timeDifference = now.timeIntervalSince(lastTime)
+            let hourDifference = timeDifference / 3600
+            
+            if hourDifference < 24 { return }
+            //  TODO: - QA 때 보여주기용 (릴리즈 시 삭제)
+//            if timeDifference < 10 { return }
+        }
+        
+        let sheetVC = VerificationReminderViewController()
+        sheetVC.setSheetLayout(detent: .semiShort)
+        sheetVC.isModalInPresentation = true
+        
+        present(sheetVC, animated: true)
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationViewController.swift
@@ -9,8 +9,10 @@ import UIKit
 
 final class WithdrawalConfirmationViewController: BaseViewController {
     
-    private let confirmationView = WithdrawalConfirmationView()
+    private let confirmationView = SemiShortModalView(semiShortModalType: .withdrawalConfirmation)
+    
     var viewModel: WithdrawalViewModel?
+    
     var selectedReason: String?
 
     override func loadView() {


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #229

## 🥔 **작업 내용**
- LocalVerificationView, LocalMapView 변경된 UI 반영
- WithdrawalConfirmationView와 이번에 추가된 지역인증 리마인더 뷰가 동일해, 재사용 가능한 SemiShortView 구현. SemiShortType을 이니셜라이저로 받습니다
- 지역인증 리마인더 VerificationReminderViewController & SpotListVC에 리마인드 로직 구현

## 🚨 참고 사항
<!-- 참고사항을 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰 16 Pro|<img src = "https://github.com/user-attachments/assets/0ab2e11f-bdfe-4a4d-a3f0-a8d56774dcad" width ="250">|

## 💥 To be sure
- [ ] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #229
