### PR TITLE
[FEAT] 리뷰 업로드 - 메뉴 추천 플로우 추가 (#243)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		157C0AC12DC689E7000B04AF /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157C0AC02DC689E7000B04AF /* UIImage+.swift */; };
 		157C0BE82DC897EE000B04AF /* SpotToggleButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157C0BE72DC897EE000B04AF /* SpotToggleButtonView.swift */; };
 		15A147212D5B256D003793EE /* LocalVerificationFlowType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A147202D5B256D003793EE /* LocalVerificationFlowType.swift */; };
+		15A15BD72E410A2500E8929E /* ReviewMenuRecommendationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A15BD62E410A2500E8929E /* ReviewMenuRecommendationViewController.swift */; };
 		15A167D92E3B6A8300062C49 /* SpotUploadPhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A167D82E3B6A8300062C49 /* SpotUploadPhotoViewController.swift */; };
 		15A167DB2E3CACB100062C49 /* SpotUploadPhotoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A167DA2E3CACB100062C49 /* SpotUploadPhotoCollectionViewCell.swift */; };
 		15A167E22E3D722B00062C49 /* AlbumFlowType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A167E12E3D722B00062C49 /* AlbumFlowType.swift */; };
@@ -394,6 +395,7 @@
 		157C0AC02DC689E7000B04AF /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		157C0BE72DC897EE000B04AF /* SpotToggleButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotToggleButtonView.swift; sourceTree = "<group>"; };
 		15A147202D5B256D003793EE /* LocalVerificationFlowType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalVerificationFlowType.swift; sourceTree = "<group>"; };
+		15A15BD62E410A2500E8929E /* ReviewMenuRecommendationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewMenuRecommendationViewController.swift; sourceTree = "<group>"; };
 		15A167D82E3B6A8300062C49 /* SpotUploadPhotoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotUploadPhotoViewController.swift; sourceTree = "<group>"; };
 		15A167DA2E3CACB100062C49 /* SpotUploadPhotoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotUploadPhotoCollectionViewCell.swift; sourceTree = "<group>"; };
 		15A167E12E3D722B00062C49 /* AlbumFlowType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumFlowType.swift; sourceTree = "<group>"; };
@@ -1134,6 +1136,7 @@
 				745C7E012D358E870074DBDB /* SpotSearchView.swift */,
 				741A07582D355F0100778219 /* ReviewFinishedViewController.swift */,
 				741A07562D3558F700778219 /* ReviewFinishedView.swift */,
+				15A15BD62E410A2500E8929E /* ReviewMenuRecommendationViewController.swift */,
 				741A06C92D35415200778219 /* DropAcornViewController.swift */,
 				741A06C72D3532E000778219 /* DropAcornView.swift */,
 				D6EA38142D42B88F002B68B9 /* SearchEmptyView.swift */,
@@ -2238,6 +2241,7 @@
 				74C782192E01504F0053AA86 /* NavigatonUtils.swift in Sources */,
 				741A07572D3558FE00778219 /* ReviewFinishedView.swift in Sources */,
 				743900932DC75451002F91B1 /* GlassmorphismType.swift in Sources */,
+				15A15BD72E410A2500E8929E /* ReviewMenuRecommendationViewController.swift in Sources */,
 				1547A88E2D35B13700E96616 /* FilterTagButton.swift in Sources */,
 				15304FC22E33C57A00EFCDEF /* CafeFeatureSelectionViewController.swift in Sources */,
 				74BBADF62D611B6B003AB16C /* PostReissueResponse.swift in Sources */,

--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -169,7 +169,7 @@ enum StringLiterals {
         
         static let whatKindOfRestaurant = "여긴 어떤 식당인가요?"
         
-        static let recommendMenu = "추천하는 메뉴를 알려주세요"
+        static let recommendMenu = "추천하는\n메뉴를 알려주세요"
         
         static let enterMenu = "메뉴를 입력해주세요"
         

--- a/ACON-iOS/ACON-iOS/Presentation/SpotUpload/View/BaseUploadInquiry/BaseUploadInquiryView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotUpload/View/BaseUploadInquiry/BaseUploadInquiryView.swift
@@ -77,12 +77,12 @@ final class BaseUploadInquiryView: BaseView {
         
         requirementLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(40)
-            $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.horizontalInset)
+            $0.horizontalEdges.equalToSuperview().inset(18 * ScreenUtils.widthRatio)
         }
 
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(requirementLabel.snp.bottom).offset(4)
-            $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.horizontalInset)
+            $0.horizontalEdges.equalToSuperview().inset(18 * ScreenUtils.widthRatio)
         }
 
         if caption == nil {

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/DropAcornViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/DropAcornViewController.swift
@@ -15,10 +15,6 @@ class DropAcornViewController: BaseNavViewController {
 
     private let dropAcornView = DropAcornView()
 
-    var reviewAcornCount: Int = 0
-
-    var possessAcornCount: Int = 0
-
 
     // MARK: - Properties
 
@@ -93,7 +89,7 @@ private extension DropAcornViewController {
 
     @objc
     func leaveReviewButtonTapped() {
-        viewModel.postReview(acornCount: reviewAcornCount)
+        viewModel.postReview()
         AmplitudeManager.shared.trackEventWithProperties(AmplitudeLiterals.EventName.upload, properties: ["click_review_acon?": true, "spot_id": viewModel.spotID])
     }
 
@@ -105,8 +101,8 @@ private extension DropAcornViewController {
             btn?.isSelected = i <= selectedIndex ? true : false
         }
         dropAcornView.acornReviewLabel.text = "\(selectedIndex+1)/5"
-        reviewAcornCount = selectedIndex + 1
-        checkAcorn(reviewAcornCount)
+        viewModel.acornCount = selectedIndex + 1
+        checkAcorn(viewModel.acornCount)
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/DropAcornViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/DropAcornViewController.swift
@@ -93,8 +93,8 @@ private extension DropAcornViewController {
 
     @objc
     func leaveReviewButtonTapped() {
-        viewModel.postReview(spotID: viewModel.spotID, acornCount: reviewAcornCount)
-        AmplitudeManager.shared.trackEventWithProperties(AmplitudeLiterals.EventName.upload, properties: ["click_review_acon?": true, "spot_id": reviewAcornCount])
+        viewModel.postReview(acornCount: reviewAcornCount)
+        AmplitudeManager.shared.trackEventWithProperties(AmplitudeLiterals.EventName.upload, properties: ["click_review_acon?": true, "spot_id": viewModel.spotID])
     }
 
     @objc

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/DropAcornViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/DropAcornViewController.swift
@@ -10,55 +10,52 @@ import UIKit
 import Lottie
 
 class DropAcornViewController: BaseNavViewController {
-    
+
     // MARK: - UI Properties
-    
+
     private let dropAcornView = DropAcornView()
-    
+
     var reviewAcornCount: Int = 0
-    
+
     var possessAcornCount: Int = 0
-    
+
+
     // MARK: - Properties
-    
-    private var spotReviewViewModel = SpotReviewViewModel()
-    
-    private var spotID: Int64 = 0
-    
-    private var spotName: String = ""
-    
-    init(spotID: Int64, spotName: String) {
-        self.spotID = spotID
-        self.spotName = spotName
-        
+
+    private let viewModel: SpotReviewViewModel
+
+    init(_ viewModel: SpotReviewViewModel) {
+        self.viewModel = viewModel
+
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
+
     // MARK: - LifeCycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
         addTarget()
         bindViewModel()
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         setPopGesture()
     }
-    
+
     override func setHierarchy() {
         super.setHierarchy()
         
         self.contentView.addSubview(dropAcornView)
     }
-    
+
     override func setLayout() {
         super.setLayout()
 
@@ -66,16 +63,16 @@ class DropAcornViewController: BaseNavViewController {
             $0.edges.equalToSuperview()
         }
     }
-    
+
     override func setStyle() {
         super.setStyle()
-        
-        self.setButtonStyle(button: leftButton, image: .icLeft)
-        self.setButtonAction(button: leftButton, target: self, action: #selector(dropAcornBackButtonTapped))
+
+        self.setBackButton()
         self.setCenterTitleLabelStyle(title: StringLiterals.Upload.upload)
-        self.dropAcornView.spotNameLabel.setLabel(text: self.spotName.abbreviatedString(20), style: .t3SB, alignment: .center)
+
+        self.dropAcornView.spotNameLabel.setLabel(text: viewModel.spotName.abbreviatedString(20), style: .t3SB, alignment: .center)
     }
-    
+
     func addTarget() {
         dropAcornView.leaveReviewButton.addTarget(self,
                                                   action: #selector(leaveReviewButtonTapped),
@@ -93,18 +90,13 @@ class DropAcornViewController: BaseNavViewController {
 // MARK: - @objc functions
 
 private extension DropAcornViewController {
-    
-    @objc
-    func dropAcornBackButtonTapped() {
-        dismiss(animated: false)
-    }
-    
+
     @objc
     func leaveReviewButtonTapped() {
-        spotReviewViewModel.postReview(spotID: spotID, acornCount: reviewAcornCount)
+        viewModel.postReview(spotID: viewModel.spotID, acornCount: reviewAcornCount)
         AmplitudeManager.shared.trackEventWithProperties(AmplitudeLiterals.EventName.upload, properties: ["click_review_acon?": true, "spot_id": reviewAcornCount])
     }
-    
+
     @objc
     func reviewAcornButtonTapped(_ sender: UIButton) {
         let selectedIndex = sender.tag
@@ -116,32 +108,32 @@ private extension DropAcornViewController {
         reviewAcornCount = selectedIndex + 1
         checkAcorn(reviewAcornCount)
     }
-    
+
 }
 
 
 // MARK: - bind ViewModel
 
 private extension DropAcornViewController {
-    
+
     func bindViewModel() {
-        self.spotReviewViewModel.onSuccessPostReview.bind { [weak self] onSuccess in
+        self.viewModel.onSuccessPostReview.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                let vc = ReviewFinishedViewController(spotName: self?.spotName ?? "")
+                let vc = ReviewFinishedViewController(spotName: self?.viewModel.spotName ?? "")
                 vc.modalPresentationStyle = .fullScreen
                 self?.present(vc, animated: false)
             }
         }
     }
-    
+
 }
 
 
 // MARK: - drop acorn 로직
 
 private extension DropAcornViewController {
-    
+
     func checkAcorn(_ dropAcorn: Int) {
         dropAcornView.dropAcornLottieView.isHidden = false
         toggleLottie(dropAcorn: dropAcorn)
@@ -155,14 +147,14 @@ private extension DropAcornViewController {
             }
         }
     }
-    
+
 }
 
 
 // MARK: - Lottie
 
 private extension DropAcornViewController {
-    
+
     func toggleLottie(dropAcorn: Int) {
         dropAcornView.dropAcornLottieView.do {
             switch dropAcorn {
@@ -182,5 +174,5 @@ private extension DropAcornViewController {
             $0.play()
         }
     }
-    
+
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/ReviewMenuRecommendationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/ReviewMenuRecommendationViewController.swift
@@ -1,0 +1,128 @@
+//
+//  ReviewMenuRecommendationViewController.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 8/5/25.
+//
+
+import UIKit
+
+class ReviewMenuRecommendationViewController: BaseNavViewController {
+
+    // MARK: - UI Properties
+
+    private let headLabel = UILabel()
+
+    private let textField = ACTextField(cornerRadius: 8, fontStyle: .b1R, borderGlassType: .buttonGlassDefault)
+
+
+    // MARK: - Properties
+
+    private let viewModel: SpotReviewViewModel
+
+
+    // MARK: - init
+
+    init(_ viewModel: SpotReviewViewModel) {
+        self.viewModel = viewModel
+
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @MainActor required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        bindObservable()
+    }
+
+
+    // MARK: - UI Setting
+
+    override func setHierarchy() {
+        super.setHierarchy()
+
+        self.contentView.addSubviews(headLabel, textField)
+    }
+
+    override func setLayout() {
+        super.setLayout()
+
+        headLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(64 * ScreenUtils.heightRatio)
+            $0.horizontalEdges.equalToSuperview().inset(18 * ScreenUtils.widthRatio)
+        }
+
+        let sizeType = SpotUploadSizeType.TextField.self
+        textField.snp.makeConstraints {
+            $0.top.equalTo(headLabel.snp.bottom).offset(32 * ScreenUtils.heightRatio)
+            $0.horizontalEdges.equalToSuperview().inset(sizeType.horizontalInset)
+            $0.height.equalTo(sizeType.height)
+        }
+    }
+
+    override func setStyle() {
+        super.setStyle()
+
+        // NOTE: 네비게이션 바
+        self.setCenterTitleLabelStyle(title: StringLiterals.Upload.upload)
+        self.setBackButton()
+        self.setNextButton()
+        self.setButtonAction(button: rightButton, target: self, action:  #selector(nextButtonTapped))
+
+        self.hideKeyboard()
+
+        headLabel.setLabel(text: StringLiterals.SpotUpload.recommendMenu, style: .h3SB, color: .acWhite)
+        textField.setPlaceholder(as: StringLiterals.SpotUpload.enterMenu)
+        updateInputUIState()
+    }
+
+}
+
+
+// MARK: - bindings
+
+private extension ReviewMenuRecommendationViewController {
+
+    func bindObservable() {
+        textField.observableText.bind { [weak self] text in
+            guard let text else { return }
+            self?.viewModel.recommendedMenu = text
+            self?.updateInputUIState()
+        }
+    }
+
+}
+
+
+// MARK: - @objc functions
+
+private extension ReviewMenuRecommendationViewController {
+
+    @objc
+    func nextButtonTapped() {
+        let vc = DropAcornViewController(viewModel)
+        self.navigationController?.pushViewController(vc, animated: false)
+    }
+
+}
+
+
+// MARK: - Helper
+
+private extension ReviewMenuRecommendationViewController {
+
+    func updateInputUIState() {
+        let menuEntered = !viewModel.recommendedMenu.isEmpty
+
+        textField.hideClearButton(isHidden: !menuEntered)
+        self.rightButton.isEnabled = menuEntered
+    }
+
+}

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/SearchEmptyView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/SearchEmptyView.swift
@@ -57,3 +57,29 @@ class SearchEmptyView: BaseView {
     }
     
 }
+
+
+// MARK: - Internal Methods
+
+extension SearchEmptyView {
+
+    func makeAddSpotButton(target: Any, action: Selector) {
+        let addSpotButton = UIButton()
+
+        self.addSubview(addSpotButton)
+
+        addSpotButton.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(20 * ScreenUtils.heightRatio)
+            $0.centerX.equalToSuperview()
+        }
+
+        addSpotButton.do {
+            $0.setAttributedTitle(text: StringLiterals.Upload.addPlaceButton,
+                                  style: .b1SB,
+                                  color: .labelAction)
+        }
+
+        addSpotButton.addTarget(target, action: action, for: .touchUpInside)
+    }
+ 
+}

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotSearchViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotSearchViewController.swift
@@ -88,6 +88,8 @@ class SpotSearchViewController: BaseNavViewController{
         self.rightButton.addTarget(self,
                                    action: #selector(nextButtonTapped),
                                     for: .touchUpInside)
+        
+        spotSearchView.searchEmptyView.makeAddSpotButton(target: self, action: #selector(addPlaceFooterTapped))
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotSearchViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotSearchViewController.swift
@@ -196,8 +196,10 @@ private extension SpotSearchViewController {
     @objc
     func nextButtonTapped() {
         AmplitudeManager.shared.trackEventWithProperties(AmplitudeLiterals.EventName.upload, properties: ["click_review_next?": true])
-        let vc = DropAcornViewController(spotID: selectedSpotID, spotName: selectedSpotName)
-        self.navigationController?.pushViewController(vc, animated: false)
+
+        let vm = SpotReviewViewModel(spotID: selectedSpotID, spotName: selectedSpotName)
+        let vc = ReviewMenuRecommendationViewController(vm)
+        self.navigationController?.pushViewController(vc, animated: true)
     }
     
     @objc

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotSearchViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotSearchViewController.swift
@@ -257,12 +257,10 @@ extension SpotSearchViewController: UICollectionViewDelegateFlowLayout {
             selectedSpotName = spotSearchViewModel.searchSuggestionData.value?[indexPath.item].spotName ?? ""
             spotSearchView.searchTextField.text = selectedSpotName
             updateSearchKeyword(selectedSpotName)
-        } else {
+        } else if collectionView == spotSearchView.searchKeywordCollectionView {
             selectedSpotID = spotSearchViewModel.searchKeywordData.value?[indexPath.item].spotID ?? 1
             selectedSpotName = spotSearchViewModel.searchKeywordData.value?[indexPath.item].spotName ?? ""
             spotSearchView.searchTextField.text = selectedSpotName
-        }
-        if collectionView == spotSearchView.searchKeywordCollectionView {
             self.dismissKeyboard()
         }
         spotSearchViewModel.getReviewVerification(spotId: selectedSpotID)

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotReviewViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotReviewViewModel.swift
@@ -17,7 +17,7 @@ class SpotReviewViewModel: Serviceable {
 
     var recommendedMenu: String = ""
 
-    var acornCount: ObservablePattern<Int> = ObservablePattern(nil)
+    var acornCount: Int = 0
 
     let onSuccessPostReview: ObservablePattern<Bool> = ObservablePattern(nil)
 
@@ -30,21 +30,23 @@ class SpotReviewViewModel: Serviceable {
     }
 
 
-    func postReview(acornCount: Int) {
+    // MARK: - Network
+
+    func postReview() {
         ACService.shared.uploadService.postReview(requestBody: PostReviewRequest(spotId: spotID, acornCount: acornCount)) { [weak self] response in
             switch response {
             case .success(_):
                 self?.onSuccessPostReview.value = true
             case .reIssueJWT:
                 self?.handleReissue { [weak self] in
-                    self?.postReview(acornCount: acornCount)
+                    self?.postReview()
                 }
             default:
                 self?.handleNetworkError { [weak self] in
-                    self?.postReview(acornCount: acornCount)
+                    self?.postReview()
                 }
             }
         }
     }
-}
 
+}

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotReviewViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotReviewViewModel.swift
@@ -8,23 +8,40 @@
 import Foundation
 
 class SpotReviewViewModel: Serviceable {
-    
+
+    // MARK: - Properties
+
+    let spotID: Int64
+
+    let spotName: String
+
+    var recommendedMenu: String = ""
+
     var acornCount: ObservablePattern<Int> = ObservablePattern(nil)
-    
+
     let onSuccessPostReview: ObservablePattern<Bool> = ObservablePattern(nil)
-    
-    func postReview(spotID: Int64, acornCount: Int) {
+
+
+    // MARK: - init
+
+    init(spotID: Int64, spotName: String) {
+        self.spotID = spotID
+        self.spotName = spotName
+    }
+
+
+    func postReview(acornCount: Int) {
         ACService.shared.uploadService.postReview(requestBody: PostReviewRequest(spotId: spotID, acornCount: acornCount)) { [weak self] response in
             switch response {
             case .success(_):
                 self?.onSuccessPostReview.value = true
             case .reIssueJWT:
                 self?.handleReissue { [weak self] in
-                    self?.postReview(spotID: spotID, acornCount: acornCount)
+                    self?.postReview(acornCount: acornCount)
                 }
             default:
                 self?.handleNetworkError { [weak self] in
-                    self?.postReview(spotID: spotID, acornCount: acornCount)
+                    self?.postReview(acornCount: acornCount)
                 }
             }
         }


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #243 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
- **리뷰 업로드**에서 **메뉴 추천 페이지**를 구현했습니다.
  - 장소 업로드에서 쓰이는 MenuRecommendationVC를 재사용하지 않고 별도의 VC로 만들었습니다.
    이유: 재사용하려면 BaseInquiryVC의 init부터 바꿔야하기도 하고, 별도로 구현하는 편이 유연성 측면에서 좋다고 판단했습니다!
- SpotReviewVM 의 구조를 살짝 바꿨습니다!
  - 생성자 수정
  - VC에 있는 acornCount 프로퍼티를 VM으로 이동
- **SpotSearchVC**에서 검색 결과가 없을 때  "메뉴 추가하기" footer가 안 보이는 문제가 있어 UI 추가했습니다.
footer를 통일감있게 보여주기 위해 EmptyView를 EmptyCell로 만드니,
텍스트필드 입력 시 UI가 hidden 되는 타이밍이 깨지는 문제가 있었습니다. 
그래서  현재의 EmptyView를 유지하고, 버튼을 생성하는 Internal method를 만들어, `SearchVC`에서만 이 버튼이 생성되도록 했습니다.


## 🚨 참고 사항
<!-- 참고사항을 적어주세요. -->
SearchVC의 collectionView didSelectItemAt 에서 
`updateSearchKeyword(selectedSpotName)` 가 추천 키워드 선택 시에만 호출되도록 되어있더라고요!
검색결과 선택 시에는 일부러 안 부른 거 맞으실까요? 혹시나 해서 여쭙니다!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰 16 Pro|<img src = "https://github.com/user-attachments/assets/999499ab-73ac-4aa3-91a6-b4c8cd91a67f" width ="250">|


## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #243
