### PR TITLE
[FEAT] API 버저닝을 위한 ACTargetType 구현, 리뷰 API 수정 (#242)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		1547A88E2D35B13700E96616 /* FilterTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547A88D2D35B13700E96616 /* FilterTagButton.swift */; };
 		1549976D2DEC51C80040242F /* SpotType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1549976C2DEC51C80040242F /* SpotType.swift */; };
 		155422A22E41D01600547471 /* ApiVersionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155422A12E41D01600547471 /* ApiVersionType.swift */; };
+		155422A42E41E00300547471 /* ACTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155422A32E41E00300547471 /* ACTargetType.swift */; };
 		1558BA1A2D318FFC00ECDEF8 /* ACTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1558BA192D318FFC00ECDEF8 /* ACTabBarController.swift */; };
 		1558BADB2D31AAF900ECDEF8 /* ACTabBarItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1558BADA2D31AAF900ECDEF8 /* ACTabBarItemType.swift */; };
 		1558BADE2D31AB6C00ECDEF8 /* SpotListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1558BADD2D31AB6C00ECDEF8 /* SpotListViewController.swift */; };
@@ -153,7 +154,6 @@
 		741E68952D3D38BC00DF99EF /* BaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741E68942D3D38B700DF99EF /* BaseService.swift */; };
 		741E68982D3D3D8E00DF99EF /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741E68972D3D3D8800DF99EF /* ErrorResponse.swift */; };
 		741E689A2D3D43FF00DF99EF /* EmptyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741E68992D3D43FA00DF99EF /* EmptyResponse.swift */; };
-		741E68A02D3D5BD400DF99EF /* TargetType+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741E689F2D3D5BCE00DF99EF /* TargetType+.swift */; };
 		741E68A22D3D5FA200DF99EF /* ACService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741E68A12D3D5F9700DF99EF /* ACService.swift */; };
 		741E68AC2D3D6DA800DF99EF /* HeaderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741E68AB2D3D6DA400DF99EF /* HeaderType.swift */; };
 		74205D2F2D40351700D11557 /* SocialType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74205D2E2D40351400D11557 /* SocialType.swift */; };
@@ -368,6 +368,7 @@
 		1547A88D2D35B13700E96616 /* FilterTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTagButton.swift; sourceTree = "<group>"; };
 		1549976C2DEC51C80040242F /* SpotType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotType.swift; sourceTree = "<group>"; };
 		155422A12E41D01600547471 /* ApiVersionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiVersionType.swift; sourceTree = "<group>"; };
+		155422A32E41E00300547471 /* ACTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACTargetType.swift; sourceTree = "<group>"; };
 		1558BA192D318FFC00ECDEF8 /* ACTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACTabBarController.swift; sourceTree = "<group>"; };
 		1558BADA2D31AAF900ECDEF8 /* ACTabBarItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACTabBarItemType.swift; sourceTree = "<group>"; };
 		1558BADD2D31AB6C00ECDEF8 /* SpotListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListViewController.swift; sourceTree = "<group>"; };
@@ -468,7 +469,6 @@
 		741E68942D3D38B700DF99EF /* BaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseService.swift; sourceTree = "<group>"; };
 		741E68972D3D3D8800DF99EF /* ErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponse.swift; sourceTree = "<group>"; };
 		741E68992D3D43FA00DF99EF /* EmptyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyResponse.swift; sourceTree = "<group>"; };
-		741E689F2D3D5BCE00DF99EF /* TargetType+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TargetType+.swift"; sourceTree = "<group>"; };
 		741E68A12D3D5F9700DF99EF /* ACService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACService.swift; sourceTree = "<group>"; };
 		741E68AB2D3D6DA400DF99EF /* HeaderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderType.swift; sourceTree = "<group>"; };
 		74205D2E2D40351400D11557 /* SocialType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialType.swift; sourceTree = "<group>"; };
@@ -1147,8 +1147,8 @@
 			isa = PBXGroup;
 			children = (
 				741E68A12D3D5F9700DF99EF /* ACService.swift */,
+				155422A32E41E00300547471 /* ACTargetType.swift */,
 				155422A12E41D01600547471 /* ApiVersionType.swift */,
-				741E689F2D3D5BCE00DF99EF /* TargetType+.swift */,
 				741E68992D3D43FA00DF99EF /* EmptyResponse.swift */,
 				741E68972D3D3D8800DF99EF /* ErrorResponse.swift */,
 				741E68942D3D38B700DF99EF /* BaseService.swift */,
@@ -2102,7 +2102,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				748D6F952D2BD4DB007690B4 /* UICollectionViewCell+.swift in Sources */,
-				741E68A02D3D5BD400DF99EF /* TargetType+.swift in Sources */,
 				741E68912D3D385A00DF99EF /* ACPlugin.swift in Sources */,
 				745B19AE2D4002A100BDBDA4 /* PostLoginResponse.swift in Sources */,
 				15C0ED522D429F7400C9ED83 /* SkeletonView.swift in Sources */,
@@ -2200,6 +2199,7 @@
 				745ECB9F2D615B73005129B0 /* AlbumTableViewController.swift in Sources */,
 				1547A8852D3595B600E96616 /* SpotListFilterModel.swift in Sources */,
 				748D6F8B2D2BD31B007690B4 /* UIStackView+.swift in Sources */,
+				155422A42E41E00300547471 /* ACTargetType.swift in Sources */,
 				748D6F912D2BD450007690B4 /* UILabel+.swift in Sources */,
 				746261772D3EA88700A4E84F /* GetAcornCountResponse.swift in Sources */,
 				745ECB9D2D614183005129B0 /* PhotoSelectionViewController.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		1547A88B2D3596B600E96616 /* SpotFilterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547A88A2D3596B600E96616 /* SpotFilterType.swift */; };
 		1547A88E2D35B13700E96616 /* FilterTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547A88D2D35B13700E96616 /* FilterTagButton.swift */; };
 		1549976D2DEC51C80040242F /* SpotType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1549976C2DEC51C80040242F /* SpotType.swift */; };
+		155422A22E41D01600547471 /* ApiVersionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155422A12E41D01600547471 /* ApiVersionType.swift */; };
 		1558BA1A2D318FFC00ECDEF8 /* ACTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1558BA192D318FFC00ECDEF8 /* ACTabBarController.swift */; };
 		1558BADB2D31AAF900ECDEF8 /* ACTabBarItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1558BADA2D31AAF900ECDEF8 /* ACTabBarItemType.swift */; };
 		1558BADE2D31AB6C00ECDEF8 /* SpotListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1558BADD2D31AB6C00ECDEF8 /* SpotListViewController.swift */; };
@@ -366,6 +367,7 @@
 		1547A88A2D3596B600E96616 /* SpotFilterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotFilterType.swift; sourceTree = "<group>"; };
 		1547A88D2D35B13700E96616 /* FilterTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTagButton.swift; sourceTree = "<group>"; };
 		1549976C2DEC51C80040242F /* SpotType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotType.swift; sourceTree = "<group>"; };
+		155422A12E41D01600547471 /* ApiVersionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiVersionType.swift; sourceTree = "<group>"; };
 		1558BA192D318FFC00ECDEF8 /* ACTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACTabBarController.swift; sourceTree = "<group>"; };
 		1558BADA2D31AAF900ECDEF8 /* ACTabBarItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACTabBarItemType.swift; sourceTree = "<group>"; };
 		1558BADD2D31AB6C00ECDEF8 /* SpotListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotListViewController.swift; sourceTree = "<group>"; };
@@ -1145,6 +1147,7 @@
 			isa = PBXGroup;
 			children = (
 				741E68A12D3D5F9700DF99EF /* ACService.swift */,
+				155422A12E41D01600547471 /* ApiVersionType.swift */,
 				741E689F2D3D5BCE00DF99EF /* TargetType+.swift */,
 				741E68992D3D43FA00DF99EF /* EmptyResponse.swift */,
 				741E68972D3D3D8800DF99EF /* ErrorResponse.swift */,
@@ -1451,15 +1454,15 @@
 		748D6F712D2BCA7E007690B4 /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				7474CFAC2E3CADF7007ACD76 /* NaverSearch */,
+				743069872D3D2EDA0033178C /* Base */,
 				740EE8252E05983F007A5DCF /* App */,
 				745B19A92D4001AD00BDBDA4 /* Auth */,
+				7474CFAC2E3CADF7007ACD76 /* NaverSearch */,
 				15CD25752D3FE2D800320006 /* SpotList */,
 				7462617C2D3F9E9400A4E84F /* SpotDetail */,
 				746F15B42D3E2041003EA031 /* LocalVerification */,
 				746261602D3E9F6000A4E84F /* Upload */,
 				D6AF15612D3E8A3700289683 /* Onboarding */,
-				743069872D3D2EDA0033178C /* Base */,
 				151003E72D5FBEE900409DF4 /* Profile */,
 				74D297EF2D63432900DDEE31 /* Image */,
 				4C6B2F322D65A15D0089BCB6 /* Withdrawal */,
@@ -2313,6 +2316,7 @@
 				15D6901E2DD723FA0009278D /* SpotDetailMoreViewController.swift in Sources */,
 				746F5BEC2DE009450081569B /* ACToastView.swift in Sources */,
 				15A167E42E3D964400062C49 /* SpotUploadSuccessViewController.swift in Sources */,
+				155422A22E41D01600547471 /* ApiVersionType.swift in Sources */,
 				74A13D672DCBC2BD007FFFC3 /* DislikeFoodCollectionViewCell.swift in Sources */,
 				D652597C2D62775C00B8176E /* CustomTextFieldView.swift in Sources */,
 				741429602D5D391000B69528 /* SettingType.swift in Sources */,

--- a/ACON-iOS/ACON-iOS/Network/App/AppTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/App/AppTargetType.swift
@@ -15,7 +15,7 @@ enum AppTargetType {
     
 }
 
-extension AppTargetType: TargetType {
+extension AppTargetType: ACTargetType {
 
     var method: Moya.Method {
         switch self {

--- a/ACON-iOS/ACON-iOS/Network/Auth/AuthTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Auth/AuthTargetType.swift
@@ -19,7 +19,7 @@ enum AuthTargetType {
     
 }
 
-extension AuthTargetType: TargetType {
+extension AuthTargetType: ACTargetType {
 
     var method: Moya.Method {
         switch self {

--- a/ACON-iOS/ACON-iOS/Network/Base/ACTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Base/ACTargetType.swift
@@ -1,15 +1,26 @@
 //
-//  TargetType+.swift
+//  ApiVersionProtocol.swift
 //  ACON-iOS
 //
-//  Created by 이수민 on 1/20/25.
+//  Created by 김유림 on 8/5/25.
 //
 
 import Foundation
 
 import Moya
 
-extension TargetType {
+// MARK: - Protocol
+
+protocol ACTargetType: TargetType {
+
+    var apiVersion: ApiVersionType { get }
+
+}
+
+
+// MARK: - Extension
+
+extension ACTargetType {
 
     var baseURL: URL {
         guard let urlString = Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.baseURL) as? String,
@@ -19,7 +30,7 @@ extension TargetType {
         return url
     }
 
-    /// NOTE: 기본 API 버전 (필요 시 개별 Target에서 오버라이드)
+    /// API 버전 기본값 (.v1). 필요 시 각 TargetType에서 오버라이드하여 변경 가능.
     var apiVersion: ApiVersionType {
         return .v1
     }

--- a/ACON-iOS/ACON-iOS/Network/Base/ApiVersionType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Base/ApiVersionType.swift
@@ -1,0 +1,19 @@
+//
+//  APIVersionType.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 8/5/25.
+//
+
+import Foundation
+
+enum ApiVersionType: String {
+
+    case v1
+    case v2
+
+    var utilPath: String {
+        return "api/\(self.rawValue)/"
+    }
+
+}

--- a/ACON-iOS/ACON-iOS/Network/Base/TargetType+.swift
+++ b/ACON-iOS/ACON-iOS/Network/Base/TargetType+.swift
@@ -10,7 +10,7 @@ import Foundation
 import Moya
 
 extension TargetType {
-    
+
     var baseURL: URL {
         guard let urlString = Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.baseURL) as? String,
               let url = URL(string: urlString) else {
@@ -18,9 +18,14 @@ extension TargetType {
         }
         return url
     }
-    
-    var utilPath: String {
-        return "api/v1/"
+
+    /// NOTE: 기본 API 버전 (필요 시 개별 Target에서 오버라이드)
+    var apiVersion: ApiVersionType {
+        return .v1
     }
-    
+
+    var utilPath: String {
+        return apiVersion.utilPath
+    }
+
 }

--- a/ACON-iOS/ACON-iOS/Network/Image/ImageTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Image/ImageTargetType.swift
@@ -17,7 +17,7 @@ enum ImageTargetType {
 
 }
 
-extension ImageTargetType: TargetType {
+extension ImageTargetType: ACTargetType {
 
     var baseURL: URL {
         switch self {

--- a/ACON-iOS/ACON-iOS/Network/LocalVerification/LocalVerificationTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/LocalVerification/LocalVerificationTargetType.swift
@@ -21,7 +21,7 @@ enum LocalVerificationTargetType {
     
 }
 
-extension LocalVerificationTargetType: TargetType {
+extension LocalVerificationTargetType: ACTargetType {
 
     var method: Moya.Method {
         switch self {

--- a/ACON-iOS/ACON-iOS/Network/Onboarding/OnboardingTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Onboarding/OnboardingTargetType.swift
@@ -15,7 +15,7 @@ enum OnboardingTargetType {
     
 }
 
-extension OnboardingTargetType: TargetType {
+extension OnboardingTargetType: ACTargetType {
 
     var method: Moya.Method {
         switch self {

--- a/ACON-iOS/ACON-iOS/Network/Profile/ProfileTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Profile/ProfileTargetType.swift
@@ -21,7 +21,7 @@ enum ProfileTargetType {
 
 }
 
-extension ProfileTargetType: TargetType {
+extension ProfileTargetType: ACTargetType {
 
     var method: Moya.Method {
         switch self {

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailTargetType.swift
@@ -20,7 +20,7 @@ enum SpotDetailTargetType {
     
 }
 
-extension SpotDetailTargetType: TargetType {
+extension SpotDetailTargetType: ACTargetType {
 
     var method: Moya.Method {
         switch self {

--- a/ACON-iOS/ACON-iOS/Network/SpotList/SpotListTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotList/SpotListTargetType.swift
@@ -15,7 +15,7 @@ enum SpotListTargetType {
 
 }
 
-extension SpotListTargetType: TargetType {
+extension SpotListTargetType: ACTargetType {
 
     var method: Moya.Method {
         switch self {

--- a/ACON-iOS/ACON-iOS/Network/Upload/DTO/GetReviewVerificationResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/Upload/DTO/GetReviewVerificationResponse.swift
@@ -9,6 +9,6 @@ import Foundation
 
 struct GetReviewVerificationResponse: Codable {
     
-    let success: Bool
+    let available: Bool
     
 }

--- a/ACON-iOS/ACON-iOS/Network/Upload/DTO/PostReviewRequest.swift
+++ b/ACON-iOS/ACON-iOS/Network/Upload/DTO/PostReviewRequest.swift
@@ -7,11 +7,13 @@
 
 import Foundation
 
-struct PostReviewRequest: Codable {
-    
+struct PostReviewRequest: Encodable {
+
     let spotId: Int64
-    
+
+    let recommendedMenu: String
+
     let acornCount: Int
-    
+
 }
 

--- a/ACON-iOS/ACON-iOS/Network/Upload/UploadTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Upload/UploadTargetType.swift
@@ -39,7 +39,7 @@ extension UploadTargetType: TargetType {
         case .getSearchKeyword:
             return utilPath + "spots/search"
         case .getReviewVerification:
-            return utilPath + "spots/verify"
+            return utilPath + "reviews/verify"
         case .getAcornCount:
             return utilPath + "members/acorn"
         }

--- a/ACON-iOS/ACON-iOS/Network/Upload/UploadTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Upload/UploadTargetType.swift
@@ -33,7 +33,7 @@ extension UploadTargetType: TargetType {
     var path: String {
         switch self {
         case .getSearchSuggestion:
-            return utilPath + "search-suggestions"
+            return utilPath + "spots/search-suggestions"
         case .postReview:
             return utilPath + "reviews"
         case .getSearchKeyword:

--- a/ACON-iOS/ACON-iOS/Network/Upload/UploadTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Upload/UploadTargetType.swift
@@ -19,7 +19,7 @@ enum UploadTargetType {
     
 }
 
-extension UploadTargetType: TargetType {
+extension UploadTargetType: ACTargetType {
 
     var method: Moya.Method {
         switch self {
@@ -29,7 +29,16 @@ extension UploadTargetType: TargetType {
             return .get
         }
     }
-    
+
+    var apiVersion: ApiVersionType {
+        switch self {
+        case .postReview:
+            return .v2
+        default:
+            return .v1
+        }
+    }
+
     var path: String {
         switch self {
         case .getSearchSuggestion:

--- a/ACON-iOS/ACON-iOS/Network/Withdrawal/WithdrawalTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/Withdrawal/WithdrawalTargetType.swift
@@ -15,7 +15,7 @@ enum WithdrawalTargetType {
     
 }
 
-extension WithdrawalTargetType: TargetType {
+extension WithdrawalTargetType: ACTargetType {
     
     var path: String {
         switch self {

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotReviewViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotReviewViewModel.swift
@@ -8,13 +8,15 @@
 import Foundation
 
 class SpotReviewViewModel: Serviceable {
-    
+
     var acornCount: ObservablePattern<Int> = ObservablePattern(nil)
-    
+
     let onSuccessPostReview: ObservablePattern<Bool> = ObservablePattern(nil)
-    
+
+    var recommendedMenu: String = ""
+
     func postReview(spotID: Int64, acornCount: Int) {
-        ACService.shared.uploadService.postReview(requestBody: PostReviewRequest(spotId: spotID, acornCount: acornCount)) { [weak self] response in
+        ACService.shared.uploadService.postReview(requestBody: PostReviewRequest(spotId: spotID, recommendedMenu: recommendedMenu, acornCount: acornCount)) { [weak self] response in
             switch response {
             case .success(_):
                 self?.onSuccessPostReview.value = true
@@ -29,5 +31,6 @@ class SpotReviewViewModel: Serviceable {
             }
         }
     }
+
 }
 

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotSearchViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/ViewModel/SpotSearchViewModel.swift
@@ -113,7 +113,7 @@ class SpotSearchViewModel: Serviceable {
         ACService.shared.uploadService.getReviewVerification(parameter: parameter) { [weak self] response in
             switch response {
             case .success(let data):
-                self?.reviewVerification.value = data.success
+                self?.reviewVerification.value = data.available
                 self?.onSuccessGetReviewVerification.value = true
             case .requestErr(let error):
                 if error.code == 40403 {


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #242 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
- API 버저닝을 위해 **ACTargetType**을 구현했습니다. (Moya의 TargetType 프로토콜 상속)
  - 우리팀 컨벤션상으로는 `ACTargetTypeProtocol`식으로 네이밍해야하지만,
  길이가 길고, Moya의 TargetType이라는 느낌이 약해지는 것 같아 간단하게 `ACTargetType`이라고 네이밍했습니다!
  혹시 `ACTargetTypeProtocol` 으로 하는 게 좋겠다고 생각하시면 말씀해주세요!
- **리뷰 API** 변경사항을 반영했습니다.
  - 리뷰 작성 API
  - 리뷰 작성 시 위치 인증 API
  - 추천 검색어 목록 조회 API


## 📸 스크린샷
<img width="817" height="89" alt="image" src="https://github.com/user-attachments/assets/4b089d12-b625-4257-a629-e6160d7e0c65" />


## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #242
