### PR TITLE
[FEAT] 장소 업로드 - fade in + slide 애니메이션 구현 (#254)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -2436,7 +2436,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2025.0806.2105;
+				CURRENT_PROJECT_VERSION = 2025.0807.0103;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KX5Q77JSUF;
@@ -2479,7 +2479,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2025.0806.2105;
+				CURRENT_PROJECT_VERSION = 2025.0807.0103;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KX5Q77JSUF;
 				GENERATE_INFOPLIST_FILE = NO;

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -2436,7 +2436,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2025.0804.0047;
+				CURRENT_PROJECT_VERSION = 2025.0806.2105;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KX5Q77JSUF;
@@ -2479,7 +2479,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2025.0804.0047;
+				CURRENT_PROJECT_VERSION = 2025.0806.2105;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KX5Q77JSUF;
 				GENERATE_INFOPLIST_FILE = NO;

--- a/ACON-iOS/ACON-iOS/Global/Extensions/UIView+.swift
+++ b/ACON-iOS/ACON-iOS/Global/Extensions/UIView+.swift
@@ -194,6 +194,7 @@ extension UIView {
     ) {
         self.transform = CGAffineTransform(translationX: 0, y: yOffset)
         self.alpha = 0
+        self.isHidden = false
 
         UIView.animate(
             withDuration: duration,
@@ -202,7 +203,6 @@ extension UIView {
             initialSpringVelocity: initialSpringVelocity,
             options: [.curveEaseOut],
             animations: {
-                self.isHidden = false
                 self.transform = .identity
                 self.alpha = 1
             },

--- a/ACON-iOS/ACON-iOS/Global/Extensions/UIView+.swift
+++ b/ACON-iOS/ACON-iOS/Global/Extensions/UIView+.swift
@@ -173,3 +173,40 @@ extension UIView {
     }
 
 }
+
+// MARK: - Animation
+
+extension UIView {
+    /// 아래에서 위로 올라오며 페이드 인하는 애니메이션
+    /// - Parameters:
+    ///   - duration: 애니메이션 전체 시간
+    ///   - delay: 지연 시간 (뷰마다 순차적으로 나타나게 하고 싶을 때 활용)
+    ///   - damping: 스프링 애니메이션 감쇠 비율 (0: 스프링 <-> 1: 스르륵)
+    ///   - initialSpringVelocity: 초기 속도
+    ///   - yOffset: 시작 위치의 y축 오프셋 (양수로 설정하면 아래서 시작)
+    func animateSlideUp(
+        duration: TimeInterval = 0.8,
+        delay: TimeInterval = 0,
+        damping: CGFloat = 1.0,
+        initialSpringVelocity: CGFloat = 0.0,
+        yOffset: CGFloat = 30
+    ) {
+        self.transform = CGAffineTransform(translationX: 0, y: yOffset)
+        self.alpha = 0
+
+        UIView.animate(
+            withDuration: duration,
+            delay: delay,
+            usingSpringWithDamping: damping,
+            initialSpringVelocity: initialSpringVelocity,
+            options: [.curveEaseOut],
+            animations: {
+                self.isHidden = false
+                self.transform = .identity
+                self.alpha = 1
+            },
+            completion: nil
+        )
+    }
+}
+

--- a/ACON-iOS/ACON-iOS/Global/Extensions/UIView+.swift
+++ b/ACON-iOS/ACON-iOS/Global/Extensions/UIView+.swift
@@ -177,6 +177,7 @@ extension UIView {
 // MARK: - Animation
 
 extension UIView {
+
     /// 아래에서 위로 올라오며 페이드 인하는 애니메이션
     /// - Parameters:
     ///   - duration: 애니메이션 전체 시간
@@ -208,5 +209,6 @@ extension UIView {
             completion: nil
         )
     }
+
 }
 

--- a/ACON-iOS/ACON-iOS/Global/Settings/Info.plist
+++ b/ACON-iOS/ACON-iOS/Global/Settings/Info.plist
@@ -54,7 +54,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2025.0804.0047</string>
+	<string>2025.0806.2105</string>
 	<key>GADApplicationIdentifier</key>
 	<string>${GAD_APPLICATION_IDENTIFIER}</string>
 	<key>GAD_AD_UNIT_ID</key>

--- a/ACON-iOS/ACON-iOS/Global/Settings/Info.plist
+++ b/ACON-iOS/ACON-iOS/Global/Settings/Info.plist
@@ -54,7 +54,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2025.0806.2105</string>
+	<string>2025.0807.0103</string>
 	<key>GADApplicationIdentifier</key>
 	<string>${GAD_APPLICATION_IDENTIFIER}</string>
 	<key>GAD_AD_UNIT_ID</key>

--- a/ACON-iOS/ACON-iOS/Global/UIComponents/ACAlert/Type/ACAlertType.swift
+++ b/ACON-iOS/ACON-iOS/Global/UIComponents/ACAlert/Type/ACAlertType.swift
@@ -19,6 +19,8 @@ enum ACAlertType: CaseIterable {
     
     case naverAPILimitExceeded // NOTE: 일일 네이버 API 호출 가능 횟수 (25000회) 초과
     case quitSpotUpload // NOTE: 장소 등록 취소
+    case deletePhoto // NOTE: 사진 삭제 (장소 업로드)
+    case spotUploadFail // NOTE: 장소 업로드 실패
     
     case libraryAccessDenied // NOTE: 사진 권한 X
     case changeNotSaved // NOTE: 프로필 변경사항 저장 X
@@ -30,8 +32,6 @@ enum ACAlertType: CaseIterable {
     
     case logout // NOTE: 로그아웃
     
-    case deletePhoto // NOTE: 사진 삭제 (장소 업로드)
-    case spotUploadFail // NOTE: 장소 업로드 실패
     
     var title: String {
         switch self {
@@ -47,7 +47,7 @@ enum ACAlertType: CaseIterable {
         case .naverAPILimitExceeded:
             return "장소 등록 마감"
         case .quitSpotUpload:
-            return "등록을 취소하시겠습니까?"
+            return "여기서 그만두면\n작성 중인 내용이 사라져요"
             
         case .libraryAccessDenied:
             return "'Acon'에 대한 라이브러리\n읽기/쓰기 기능이 없습니다."
@@ -128,11 +128,11 @@ enum ACAlertType: CaseIterable {
             return "설정으로 가기"
         case .naverAPILimitExceeded:
             return "제보하기"
-        case .changeNotSaved, .quitSpotUpload:
+        case .changeNotSaved:
             return "나가기"
         case .changeVerifiedArea:
             return "변경하기"
-        case .quitOnboarding:
+        case .quitOnboarding, .quitSpotUpload:
             return "그만두기"
         case .logout:
             return "로그아웃"

--- a/ACON-iOS/ACON-iOS/Presentation/SpotUpload/Type/SpotUploadType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotUpload/Type/SpotUploadType.swift
@@ -122,3 +122,12 @@ extension SpotUploadType {
     }
 
 }
+
+
+// MARK: - 추천 메뉴
+
+extension SpotUploadType {
+
+    static let recommendedMenuMaxLength: Int = 30
+
+}

--- a/ACON-iOS/ACON-iOS/Presentation/SpotUpload/View/BaseUploadInquiry/BaseUploadInquiryView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotUpload/View/BaseUploadInquiry/BaseUploadInquiryView.swift
@@ -15,9 +15,9 @@ final class BaseUploadInquiryView: BaseView {
     
     private let scrollContentView = UIView()
     
-    private let requirementLabel = UILabel()
+    let requirementLabel = UILabel()
 
-    private let titleLabel = UILabel()
+    let titleLabel = UILabel()
 
     let captionLabel = UILabel()
 
@@ -117,6 +117,8 @@ final class BaseUploadInquiryView: BaseView {
         if let caption {
             captionLabel.setLabel(text: caption, style: .t5R, color: .gray500)
         }
+
+        [requirementLabel, titleLabel, captionLabel, contentView].forEach { $0.isHidden = true }
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotUpload/View/BaseUploadInquiry/BaseUploadInquiryViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotUpload/View/BaseUploadInquiry/BaseUploadInquiryViewController.swift
@@ -14,6 +14,9 @@ class BaseUploadInquiryViewController: BaseViewController {
     let viewModel: SpotUploadViewModel
     let spotUploadInquiryView: BaseUploadInquiryView
 
+    let hasCaption: Bool
+    var isInitialAppear: Bool = true
+
     // NOTE: 하위 뷰컨에서 override하여 설정
     var contentViews: [UIView] { [] }
     var canGoPrevious: Bool { true }
@@ -24,6 +27,7 @@ class BaseUploadInquiryViewController: BaseViewController {
 
     init(viewModel: SpotUploadViewModel, requirement: RequirementType, title: String, caption: String? = nil) {
         self.viewModel = viewModel
+        self.hasCaption = caption != nil
         self.spotUploadInquiryView = BaseUploadInquiryView(requirement: requirement, title: title, caption: caption)
 
         super.init(nibName: nil, bundle: nil)
@@ -44,6 +48,15 @@ class BaseUploadInquiryViewController: BaseViewController {
         super.viewWillAppear(animated)
 
         updatePagingButtonStates()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        if isInitialAppear {
+            playSlideUpAnimation()
+            isInitialAppear = false
+        }
     }
 
 
@@ -84,6 +97,15 @@ class BaseUploadInquiryViewController: BaseViewController {
                 $0.height.equalTo(sizeType.height)
             }
         }
+    }
+
+    func playSlideUpAnimation() {
+        let titleDelay: TimeInterval = 0.3
+        let contentDelay: TimeInterval = 0.6
+        spotUploadInquiryView.requirementLabel.animateSlideUp()
+        spotUploadInquiryView.titleLabel.animateSlideUp(delay: titleDelay)
+        if hasCaption { spotUploadInquiryView.captionLabel.animateSlideUp(delay: 2 * titleDelay) }
+        spotUploadInquiryView.contentView.animateSlideUp(delay: contentDelay + titleDelay * (hasCaption ? 2 : 1))
     }
 
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotUpload/View/InquiryPages/MenuRecommendationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotUpload/View/InquiryPages/MenuRecommendationViewController.swift
@@ -89,6 +89,13 @@ private extension MenuRecommendationViewController {
         textField.observableText.bind { [weak self] text in
             guard let text else { return }
             self?.textField.hideClearButton(isHidden: text.isEmpty)
+
+            // NOTE: 글자수 제한
+            guard text.count <= SpotUploadType.recommendedMenuMaxLength else {
+                self?.textField.text?.removeLast()
+                return
+            }
+
             self?.viewModel.recommendedMenu = text
             self?.updatePagingButtonStates()
         }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotUpload/View/SpotUpload/SpotUploadViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotUpload/View/SpotUpload/SpotUploadViewController.swift
@@ -190,7 +190,10 @@ private extension SpotUploadViewController {
     @objc func goToPreviousPage() {
         guard currentIndex > 0 else { return }
         currentIndex -= 1
+
+        // TODO: setXButtonAction()이 추가되면 nextButton UI 업데이트가 안 됨. 뷰 렌더링과 관련된 로직을 건들이는 것 같은데, 일단 layoutIfNeeded() 호출하여 해결. 추후 정확한 원인 파악 후 해결 필요.
         self.setXButtonAction()
+        nextButton.layoutIfNeeded()
         pageVC.setViewControllers([pages[currentIndex]], direction: .reverse, animated: true, completion: nil)
     }
 
@@ -203,6 +206,7 @@ private extension SpotUploadViewController {
         if currentIndex < lastIndex { // NOTE: 다음페이지
             currentIndex += 1
             self.setXButtonAction()
+            nextButton.layoutIfNeeded()
             pageVC.setViewControllers([pages[currentIndex]], direction: .forward, animated: true, completion: nil)
         } else if currentIndex == lastIndex { // NOTE: 마지막페이지 -> post
             viewModel.uploadSpot()

--- a/ACON-iOS/ACON-iOS/Presentation/SpotUpload/View/SpotUpload/SpotUploadViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotUpload/View/SpotUpload/SpotUploadViewController.swift
@@ -91,7 +91,7 @@ final class SpotUploadViewController: BaseNavViewController {
     override func setStyle() {
         super.setStyle()
 
-        setXButtonAction()
+        setXButton(#selector(showQuitAlert))
         
         self.setCenterTitleLabelStyle(title: StringLiterals.SpotUpload.spotUpload)
 
@@ -128,18 +128,6 @@ final class SpotUploadViewController: BaseNavViewController {
                              for: .touchUpInside)
     }
 
-    private func setXButtonAction() {
-        let currentVC = pages[currentIndex]
-        
-        leftButton.removeTarget(nil, action: nil, for: .touchUpInside)
-        
-        if currentVC is SpotUploadSearchViewController {
-            setXButton(#selector(showQuitAlert))
-        } else {
-            setXButton(#selector(navigateToTabBar))
-        }
-    }
-    
 }
 
 
@@ -190,10 +178,6 @@ private extension SpotUploadViewController {
     @objc func goToPreviousPage() {
         guard currentIndex > 0 else { return }
         currentIndex -= 1
-
-        // TODO: setXButtonAction()이 추가되면 nextButton UI 업데이트가 안 됨. 뷰 렌더링과 관련된 로직을 건들이는 것 같은데, 일단 layoutIfNeeded() 호출하여 해결. 추후 정확한 원인 파악 후 해결 필요.
-        self.setXButtonAction()
-        nextButton.layoutIfNeeded()
         pageVC.setViewControllers([pages[currentIndex]], direction: .reverse, animated: true, completion: nil)
     }
 
@@ -205,8 +189,6 @@ private extension SpotUploadViewController {
         }
         if currentIndex < lastIndex { // NOTE: 다음페이지
             currentIndex += 1
-            self.setXButtonAction()
-            nextButton.layoutIfNeeded()
             pageVC.setViewControllers([pages[currentIndex]], direction: .forward, animated: true, completion: nil)
         } else if currentIndex == lastIndex { // NOTE: 마지막페이지 -> post
             viewModel.uploadSpot()

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/ReviewMenuRecommendationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/ReviewMenuRecommendationViewController.swift
@@ -95,6 +95,13 @@ private extension ReviewMenuRecommendationViewController {
     func bindObservable() {
         textField.observableText.bind { [weak self] text in
             guard let text else { return }
+
+            // NOTE: 글자수 제한
+            guard text.count <= SpotUploadType.recommendedMenuMaxLength else {
+                self?.textField.text?.removeLast()
+                return
+            }
+
             self?.viewModel.recommendedMenu = text
             self?.updateInputUIState()
         }

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/ReviewMenuRecommendationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/ReviewMenuRecommendationViewController.swift
@@ -70,6 +70,8 @@ class ReviewMenuRecommendationViewController: BaseNavViewController {
     override func setStyle() {
         super.setStyle()
 
+        self.setPopGesture()
+
         // NOTE: 네비게이션 바
         self.setCenterTitleLabelStyle(title: StringLiterals.Upload.upload)
         self.setBackButton()


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #254 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->

**`fade in + slide` 애니메이션 UIView extension 메소드를 구현, 
장소 업로드 페이지에 반영했습니다.**

- 애니메이션은 최초 1번만 실행됩니다
  -> 이전 페이지로 돌아가면 애니메이션 재생 X

- 메소드 파라미터 설명
  - duration: 애니메이션 전체 시간
  - delay: 지연 시간 (뷰마다 순차적으로 나타나게 하고 싶을 때 활용)
  - damping: 스프링 애니메이션 감쇠 비율 (0: 스프링 <-> 1: 스르륵)
  - initialSpringVelocity: 초기 속도
  - yOffset: 시작 위치의 y축 오프셋 (양수로 설정하면 아래서 시작)
 
```
extension UIView {
    func animateSlideUp(
        duration: TimeInterval = 0.8,
        delay: TimeInterval = 0,
        damping: CGFloat = 1.0,
        initialSpringVelocity: CGFloat = 0.0,
        yOffset: CGFloat = 30
    )
```

### 추가 수정사항

**1. 업로드 x버튼 눌렀을 때 Alert**
- 모든 페이지에서 뜨도록 수정 (기존: Search 페이지에서만 Alert 떴음)
- 문구 수정함

**2. ReviewMenuRecommendationVC** 네비게이션 pop gesture 설정

**3. 추천메뉴 글자수 30 넘어가면 입력 막기**

## 📸 스크린샷

https://github.com/user-attachments/assets/40e0713e-22f0-4d9d-afdd-ec9a14640b4f


## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #254
