### PR TITLE
[CHORE] 지역 인증 - 건너뛰기 버튼을 onboarding시에만 활성화 (#256)

### DIFF
--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -437,7 +437,7 @@ enum StringLiterals {
         
         static let verifiedArea = "인증 지역"
         
-        static let verifiedAreaDescription = "등록한 지 1주일 이내 지역은 수정이 가능하며 이후 3개월 동안\n변경이 불가해요."
+        static let verifiedAreaDescription = "등록한 지 1주일 이내 지역은 수정이 가능하며\n이후 3개월 동안 변경이 불가해요."
         
         static let nicknamePlaceholder = "닉네임을 입력해주세요"
         

--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -19,6 +19,8 @@ enum StringLiterals {
         
         static let hasPreference = "hasPreference"
         
+        static let lastLocalVerificationAlertTime = "lastLocalVerificationAlertTime"
+        
     }
     
     enum Error {

--- a/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
+++ b/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
@@ -47,8 +47,9 @@ final class AuthManager {
                     continuation.resume(returning: true)
                 case .requestErr(let error):
                     if error.code == 40088 {
+                        print("❄️ remove token")
                         self.removeToken()
-                        NavigationUtils.navigateToSplash()
+                        continuation.resume(returning: false)
                     }
                 default:
                     continuation.resume(returning: false)

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
@@ -38,11 +38,13 @@ class LocalVerificationViewController: BaseNavViewController {
         
         addTarget()
         bindViewModel()
-        self.setSkipButton() {
-            let now = Date()
-            UserDefaults.standard.set(now, forKey: "lastLocalVerificationAlertTime")
-            
-            NavigationUtils.naviateToLoginOnboarding()
+        if self.localVerificationViewModel.flowType == .onboarding {
+            self.setSkipButton() {
+                let now = Date()
+                UserDefaults.standard.set(now, forKey: StringLiterals.UserDefaults.lastLocalVerificationAlertTime)
+
+                NavigationUtils.naviateToLoginOnboarding()
+            }
         }
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/VerificationReminderViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/VerificationReminderViewController.swift
@@ -38,7 +38,7 @@ private extension VerificationReminderViewController {
     @objc
     func cancelButtonTapped() {
         let now = Date()
-        UserDefaults.standard.set(now, forKey: "lastLocalVerificationAlertTime")
+        UserDefaults.standard.set(now, forKey: StringLiterals.UserDefaults.lastLocalVerificationAlertTime)
         dismiss(animated: true)
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -753,7 +753,7 @@ private extension SpotListViewController {
         guard AuthManager.shared.hasToken else { return }
         guard !AuthManager.shared.hasVerifiedArea else { return }
         
-        let lastAlertTime = UserDefaults.standard.object(forKey: "lastLocalVerificationAlertTime") as? Date
+        let lastAlertTime = UserDefaults.standard.object(forKey: StringLiterals.UserDefaults.lastLocalVerificationAlertTime) as? Date
         let now = Date()
         
         if let lastTime = lastAlertTime {


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #256 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
- 건너뛰기 버튼 onboarding 플로우에서만 활성화
- 지역인증 수정뷰 - description 줄바꿈 수정
- UserDefaults StringLiterals로 수정

## 📸 스크린샷
| 지역인증뷰 (setting 플로우) | 지역인증 수정뷰 |
|:--:|:--:|
|<img src="https://github.com/user-attachments/assets/02852205-1397-4ebb-9e5c-1ce2b1fffb33" width="250"> | <img width="300" src="https://github.com/user-attachments/assets/9755e985-a678-41b8-b24c-caa5fc3aabbb"> |


## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #256
