### PR TITLE
[FEAT] UserDefaultsManager 구현, 앱 실행 시 토큰 갱신 로직 구현 (#268)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		15304FC22E33C57A00EFCDEF /* CafeFeatureSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15304FC12E33C57A00EFCDEF /* CafeFeatureSelectionViewController.swift */; };
 		15304FC82E33EFA600EFCDEF /* SpotUploadSizeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15304FC72E33EFA600EFCDEF /* SpotUploadSizeType.swift */; };
 		1530CC792DDFC0D100EB4AEC /* SpotNoImageContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1530CC782DDFC0D100EB4AEC /* SpotNoImageContentView.swift */; };
+		153B78252E74090700B772F9 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153B78242E74090700B772F9 /* UserDefaultsManager.swift */; };
 		15432E7D2E41ECCA0005DB90 /* PostSpotUploadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15432E7C2E41ECCA0005DB90 /* PostSpotUploadRequest.swift */; };
 		15432E802E41ECDD0005DB90 /* SpotUploadTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15432E7F2E41ECDD0005DB90 /* SpotUploadTargetType.swift */; };
 		15432E822E41ECF40005DB90 /* SpotUploadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15432E812E41ECF40005DB90 /* SpotUploadService.swift */; };
@@ -369,6 +370,7 @@
 		15304FC12E33C57A00EFCDEF /* CafeFeatureSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeFeatureSelectionViewController.swift; sourceTree = "<group>"; };
 		15304FC72E33EFA600EFCDEF /* SpotUploadSizeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotUploadSizeType.swift; sourceTree = "<group>"; };
 		1530CC782DDFC0D100EB4AEC /* SpotNoImageContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotNoImageContentView.swift; sourceTree = "<group>"; };
+		153B78242E74090700B772F9 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		15432E7C2E41ECCA0005DB90 /* PostSpotUploadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSpotUploadRequest.swift; sourceTree = "<group>"; };
 		15432E7F2E41ECDD0005DB90 /* SpotUploadTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotUploadTargetType.swift; sourceTree = "<group>"; };
 		15432E812E41ECF40005DB90 /* SpotUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotUploadService.swift; sourceTree = "<group>"; };
@@ -1348,6 +1350,7 @@
 				741429662D5D550400B69528 /* AppVersionManager.swift */,
 				7462D0242D4262EF00580464 /* AuthManager.swift */,
 				1515CE0C2E00823B00A559A2 /* DeepLinkManager.swift */,
+				153B78242E74090700B772F9 /* UserDefaultsManager.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -2338,6 +2341,7 @@
 				740EE8282E059875007A5DCF /* GetAppUpdateRequest.swift in Sources */,
 				15304FC02E33BAA900EFCDEF /* ValueRatingViewController.swift in Sources */,
 				15F45F842D6664C900BD6B9C /* LoginLockOverlayView.swift in Sources */,
+				153B78252E74090700B772F9 /* UserDefaultsManager.swift in Sources */,
 				746261692D3EA33300A4E84F /* PostReviewRequest.swift in Sources */,
 				15CD257E2D3FF4F200320006 /* SpotListTargetType.swift in Sources */,
 				15A246142DE79D7E00469272 /* NoMatchingSpotType.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -2476,7 +2476,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2025.0824.2309;
+				CURRENT_PROJECT_VERSION = 2025.0915.0016;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KX5Q77JSUF;
@@ -2495,7 +2495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ACON.ACON-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2519,7 +2519,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2025.0824.2309;
+				CURRENT_PROJECT_VERSION = 2025.0915.0016;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KX5Q77JSUF;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -2537,7 +2537,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ACON.ACON-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
+++ b/ACON-iOS/ACON-iOS/Global/Literals/StringLiterals.swift
@@ -9,22 +9,6 @@ import Foundation
 
 enum StringLiterals {
     
-    enum UserDefaults {
-        
-        static let accessToken = "accessToken"
-        
-        static let refreshToken = "refreshToken"
-        
-        static let hasVerifiedArea = "hasVerifiedArea"
-        
-        static let hasPreference = "hasPreference"
-        
-        static let lastLocalVerificationAlertTime = "lastLocalVerificationAlertTime"
-        
-        static let hasSeenTutorial = "hasSeenTutorial"
-        
-    }
-    
     enum Error {
         
         static let networkErrorOccurred = "일시적인 오류가 발생했습니다."

--- a/ACON-iOS/ACON-iOS/Global/Protocols/Serviceable.swift
+++ b/ACON-iOS/ACON-iOS/Global/Protocols/Serviceable.swift
@@ -23,17 +23,13 @@ extension Serviceable {
                         print("❄️ 기존 서버통신 다시 성공")
                         retryAction()
                     } else {
-                        for key in UserDefaults.standard.dictionaryRepresentation().keys {
-                            UserDefaults.standard.removeObject(forKey: key.description)
-                        }
+                        UserDefaultsManager.removeTokens()
                         NavigationUtils.navigateToSplash()
                     }
                 }
             } catch {
                 DispatchQueue.main.async {
-                    for key in UserDefaults.standard.dictionaryRepresentation().keys {
-                        UserDefaults.standard.removeObject(forKey: key.description)
-                    }
+                    UserDefaultsManager.removeTokens()
                     NavigationUtils.navigateToSplash()
                 }
             }

--- a/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
+++ b/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
@@ -12,8 +12,8 @@ final class AuthManager {
     static let shared = AuthManager()
     private init() {}
 
-    // NOTE: access token 갱신 간격: 2시간 30분(9000초)
-    private let refreshInterval: TimeInterval = 2.5 * 60 * 60
+    // NOTE: access token 갱신 간격: 3시간 (10,800초)
+    private let refreshInterval: TimeInterval = 3 * 60 * 60
 
     var hasToken: Bool {
         return UserDefaultsManager.get(String.self, forKey: .accessToken) != nil
@@ -60,7 +60,7 @@ final class AuthManager {
         UserDefaultsManager.set(now, forKey: .lastTokenRefreshDate)
     }
 
-    // NOTE: access token 유효시간이 30분 미만이면 true
+    // NOTE: access token이 만료되었으면 true
     func needsTokenRefresh() -> Bool {
         guard let lastRefresh = UserDefaultsManager.get(Date.self, forKey: .lastTokenRefreshDate) else {
             return true

--- a/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
+++ b/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
@@ -11,7 +11,10 @@ final class AuthManager {
 
     static let shared = AuthManager()
     private init() {}
-    
+
+    // NOTE: access token 갱신 간격: 2시간 30분(9000초)
+    private let refreshInterval: TimeInterval = 2.5 * 60 * 60
+
     var hasToken: Bool {
         return UserDefaultsManager.get(String.self, forKey: .accessToken) != nil
     }
@@ -37,6 +40,7 @@ final class AuthManager {
                     print("❄️ token refreshed success")
                     UserDefaultsManager.set(data.accessToken, forKey: .accessToken)
                     UserDefaultsManager.set(data.refreshToken, forKey: .refreshToken)
+                    AuthManager.shared.updateLastTokenRefreshDate()
                     continuation.resume(returning: true)
                 case .requestErr(let error):
                     if error.code == 40088 {
@@ -50,5 +54,20 @@ final class AuthManager {
             }
         }
     }
-    
+
+    func updateLastTokenRefreshDate() {
+        let now = Date()
+        UserDefaultsManager.set(now, forKey: .lastTokenRefreshDate)
+    }
+
+    // NOTE: access token 유효시간이 30분 미만이면 true
+    func needsTokenRefresh() -> Bool {
+        guard let lastRefresh = UserDefaultsManager.get(Date.self, forKey: .lastTokenRefreshDate) else {
+            return true
+        }
+        let elapsed = Date().timeIntervalSince(lastRefresh)
+        print("❄️ token elapsed: \(elapsed) / \(refreshInterval) seconds")
+        return elapsed >= refreshInterval
+    }
+
 }

--- a/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
+++ b/ACON-iOS/ACON-iOS/Global/Service/AuthManager.swift
@@ -8,54 +8,40 @@
 import UIKit
 
 final class AuthManager {
-    
+
     static let shared = AuthManager()
     private init() {}
     
     var hasToken: Bool {
-        get {
-            UserDefaults.standard.string(forKey: StringLiterals.UserDefaults.accessToken) != nil
-        }
+        return UserDefaultsManager.get(String.self, forKey: .accessToken) != nil
     }
-    
+
     var hasVerifiedArea: Bool {
-        get {
-            UserDefaults.standard.bool(forKey: StringLiterals.UserDefaults.hasVerifiedArea)
-        }
+        return UserDefaultsManager.get(Bool.self, forKey: .hasVerifiedArea) ?? false
     }
-    
+
     var hasPreference: Bool {
-        get {
-            UserDefaults.standard.bool(forKey: StringLiterals.UserDefaults.hasPreference)
-        }
+        return UserDefaultsManager.get(Bool.self, forKey: .hasPreference) ?? false
     }
-    
+
     var hasSeenTutorial: Bool {
-        get {
-            UserDefaults.standard.bool(forKey: StringLiterals.UserDefaults.hasSeenTutorial)
-        }
-    }
-    
-    func removeToken() {
-        [StringLiterals.UserDefaults.accessToken,
-         StringLiterals.UserDefaults.refreshToken].forEach { UserDefaults.standard.removeObject(forKey: $0)
-        }
+        return UserDefaultsManager.get(Bool.self, forKey: .hasSeenTutorial) ?? false
     }
 
     func handleTokenRefresh() async throws -> Bool {
-        let refreshToken = UserDefaults.standard.string(forKey: StringLiterals.UserDefaults.refreshToken) ?? ""
+        let refreshToken = UserDefaultsManager.get(String.self, forKey: .refreshToken) ?? ""
         return try await withCheckedThrowingContinuation { continuation in
             ACService.shared.authService.postReissue(PostReissueRequest(refreshToken: refreshToken)) { response in
                 switch response {
                 case .success(let data):
                     print("❄️ token refreshed success")
-                    UserDefaults.standard.set(data.accessToken, forKey: StringLiterals.UserDefaults.accessToken)
-                    UserDefaults.standard.set(data.refreshToken, forKey: StringLiterals.UserDefaults.refreshToken)
+                    UserDefaultsManager.set(data.accessToken, forKey: .accessToken)
+                    UserDefaultsManager.set(data.refreshToken, forKey: .refreshToken)
                     continuation.resume(returning: true)
                 case .requestErr(let error):
                     if error.code == 40088 {
                         print("❄️ remove token")
-                        self.removeToken()
+                        UserDefaultsManager.removeTokens()
                         continuation.resume(returning: false)
                     }
                 default:

--- a/ACON-iOS/ACON-iOS/Global/Service/UserDefaultsManager.swift
+++ b/ACON-iOS/ACON-iOS/Global/Service/UserDefaultsManager.swift
@@ -12,11 +12,13 @@ struct UserDefaultsManager {
     enum Keys: String, CaseIterable {
         case accessToken
         case refreshToken
-        case lastTokenRefreshDate
+
         case hasVerifiedArea
         case hasPreference
-        case lastLocalVerificationAlertTime
         case hasSeenTutorial // NOTE: 초기화되면 안 됨
+
+        case lastTokenRefreshDate
+        case lastLocalVerificationAlertDate
     }
 
 
@@ -39,9 +41,12 @@ struct UserDefaultsManager {
     static func remove(forKey key: Keys) {
         UserDefaults.standard.removeObject(forKey: key.rawValue)
     }
-    
-    // NOTE: hasSeenTutorial을 제외하고 초기화
-    static func removeAll() {
+
+    /// 앱에서 정의한 UserDefaults를 초기화합니다.
+    /// - Note:
+    ///   - 시스템에서 사용하는 UserDefaults 키는 영향을 받지 않습니다.
+    ///   - `hasSeenTutorial` 키는 유지됩니다.
+    static func resetAppUserDefaults() {
         for key in Keys.allCases {
             if key == .hasSeenTutorial { continue }
             remove(forKey: key)

--- a/ACON-iOS/ACON-iOS/Global/Service/UserDefaultsManager.swift
+++ b/ACON-iOS/ACON-iOS/Global/Service/UserDefaultsManager.swift
@@ -1,0 +1,57 @@
+//
+//  UserDefaultsManager.swift
+//  ACON-iOS
+//
+//  Created by 김유림 on 9/12/25.
+//
+
+import Foundation
+
+struct UserDefaultsManager {
+
+    enum Keys: String, CaseIterable {
+        case accessToken
+        case refreshToken
+        case lastTokenRefreshDate
+        case hasVerifiedArea
+        case hasPreference
+        case lastLocalVerificationAlertTime
+        case hasSeenTutorial // NOTE: 초기화되면 안 됨
+    }
+
+
+    // MARK: - 생성/수정
+
+    static func set<T>(_ value: T, forKey key: Keys) {
+        UserDefaults.standard.set(value, forKey: key.rawValue)
+    }
+
+
+    // MARK: - 읽기
+
+    static func get<T>(_ type: T.Type, forKey key: Keys) -> T? {
+        return UserDefaults.standard.object(forKey: key.rawValue) as? T
+    }
+
+
+    // MARK: - 삭제
+
+    static func remove(forKey key: Keys) {
+        UserDefaults.standard.removeObject(forKey: key.rawValue)
+    }
+    
+    // NOTE: hasSeenTutorial을 제외하고 초기화
+    static func removeAll() {
+        for key in Keys.allCases {
+            if key == .hasSeenTutorial { continue }
+            remove(forKey: key)
+        }
+    }
+
+    static func removeTokens() {
+        [Keys.accessToken, Keys.refreshToken].forEach {
+            remove(forKey: $0)
+        }
+    }
+
+}

--- a/ACON-iOS/ACON-iOS/Global/Settings/Info.plist
+++ b/ACON-iOS/ACON-iOS/Global/Settings/Info.plist
@@ -29,7 +29,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>2.1.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -54,7 +54,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2025.0824.2309</string>
+	<string>2025.0915.0016</string>
 	<key>GADApplicationIdentifier</key>
 	<string>${GAD_APPLICATION_IDENTIFIER}</string>
 	<key>GAD_AD_UNIT_ID</key>

--- a/ACON-iOS/ACON-iOS/Global/Utils/Enums/HeaderType.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/Enums/HeaderType.swift
@@ -18,7 +18,7 @@ enum HeaderType {
     }
     
     static func headerWithToken() -> [String: String] {
-        if let token = UserDefaults.standard.string(forKey: StringLiterals.UserDefaults.accessToken) {
+        if let token = UserDefaultsManager.get(String.self, forKey: .accessToken) {
             return ["Content-Type" : "application/json", "Authorization" : "Bearer " + token]
         } else {
             return basicHeader
@@ -26,7 +26,7 @@ enum HeaderType {
     }
     
     static func tokenOnly() -> [String:String] {
-        if let token = UserDefaults.standard.string(forKey: StringLiterals.UserDefaults.accessToken) {
+        if let token = UserDefaultsManager.get(String.self, forKey: .accessToken) {
             return ["Authorization" : "Bearer " + token]
         } else {
             return noHeader

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
@@ -41,7 +41,7 @@ class LocalVerificationViewController: BaseNavViewController {
         if self.localVerificationViewModel.flowType == .onboarding {
             self.setSkipButton() {
                 let now = Date()
-                UserDefaults.standard.set(now, forKey: StringLiterals.UserDefaults.lastLocalVerificationAlertTime)
+                UserDefaultsManager.set(now, forKey: .lastLocalVerificationAlertTime)
 
                 NavigationUtils.naviateToLoginOnboarding()
             }

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/LocalVerificationViewController.swift
@@ -41,7 +41,7 @@ class LocalVerificationViewController: BaseNavViewController {
         if self.localVerificationViewModel.flowType == .onboarding {
             self.setSkipButton() {
                 let now = Date()
-                UserDefaultsManager.set(now, forKey: .lastLocalVerificationAlertTime)
+                UserDefaultsManager.set(now, forKey: .lastLocalVerificationAlertDate)
 
                 NavigationUtils.naviateToLoginOnboarding()
             }

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/VerificationReminderViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/VerificationReminderViewController.swift
@@ -38,7 +38,7 @@ private extension VerificationReminderViewController {
     @objc
     func cancelButtonTapped() {
         let now = Date()
-        UserDefaultsManager.set(now, forKey: .lastLocalVerificationAlertTime)
+        UserDefaultsManager.set(now, forKey: .lastLocalVerificationAlertDate)
         dismiss(animated: true)
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/VerificationReminderViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/View/VerificationReminderViewController.swift
@@ -38,7 +38,7 @@ private extension VerificationReminderViewController {
     @objc
     func cancelButtonTapped() {
         let now = Date()
-        UserDefaults.standard.set(now, forKey: StringLiterals.UserDefaults.lastLocalVerificationAlertTime)
+        UserDefaultsManager.set(now, forKey: .lastLocalVerificationAlertTime)
         dismiss(animated: true)
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/LocalVerification/ViewModel/LocalVerificationViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/LocalVerification/ViewModel/LocalVerificationViewModel.swift
@@ -68,8 +68,7 @@ class LocalVerificationViewModel: Serviceable {
             case .success:
                 self?.onPostLocalAreaSuccess.value = true
                 if !AuthManager.shared.hasVerifiedArea {
-                    UserDefaults.standard.set(true,
-                                              forKey: StringLiterals.UserDefaults.hasVerifiedArea)
+                    UserDefaultsManager.set(true, forKey: .hasVerifiedArea)
                 }
             case .requestErr(let error):
                 self?.onPostLocalAreaSuccess.value = false

--- a/ACON-iOS/ACON-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -54,10 +54,11 @@ class LoginViewModel: Serviceable {
         ACService.shared.authService.postLogin(PostLoginRequest(socialType: socialType, idToken: idToken)){ [weak self] response in
             switch response {
             case .success(let data):
-                UserDefaults.standard.set(data.accessToken, forKey: StringLiterals.UserDefaults.accessToken)
-                UserDefaults.standard.set(data.refreshToken, forKey: StringLiterals.UserDefaults.refreshToken)
-                UserDefaults.standard.set(data.hasVerifiedArea, forKey: StringLiterals.UserDefaults.hasVerifiedArea)
-                UserDefaults.standard.set(data.hasPreference, forKey: StringLiterals.UserDefaults.hasPreference)
+                UserDefaultsManager.set(data.accessToken, forKey: .accessToken)
+                UserDefaultsManager.set(data.refreshToken, forKey: .refreshToken)
+                UserDefaultsManager.set(data.hasVerifiedArea, forKey: .hasVerifiedArea)
+                UserDefaultsManager.set(data.hasPreference, forKey: .hasPreference)
+
                 AmplitudeManager.shared.setUserID(data.externalUUID)
                 AmplitudeManager.shared.setUserProperty(userProperties: ["id": data.externalUUID])
                 self?.onSuccessLogin.value = true

--- a/ACON-iOS/ACON-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -59,6 +59,8 @@ class LoginViewModel: Serviceable {
                 UserDefaultsManager.set(data.hasVerifiedArea, forKey: .hasVerifiedArea)
                 UserDefaultsManager.set(data.hasPreference, forKey: .hasPreference)
 
+                AuthManager.shared.updateLastTokenRefreshDate()
+
                 AmplitudeManager.shared.setUserID(data.externalUUID)
                 AmplitudeManager.shared.setUserProperty(userProperties: ["id": data.externalUUID])
                 self?.onSuccessLogin.value = true

--- a/ACON-iOS/ACON-iOS/Presentation/Onboarding/View/Tutorial/TutorialPages/StartNowViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Onboarding/View/Tutorial/TutorialPages/StartNowViewController.swift
@@ -128,7 +128,7 @@ private extension StartNowViewController {
 
     @objc
     func tappedStartButton() {
-        UserDefaults.standard.set(true, forKey: StringLiterals.UserDefaults.hasSeenTutorial)
+        UserDefaultsManager.set(true, forKey: .hasSeenTutorial)
         NavigationUtils.navigateToTabBar()
     }
 

--- a/ACON-iOS/ACON-iOS/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -23,8 +23,7 @@ class OnboardingViewModel: Serviceable {
             case .success:
                 onPutOnboardingSuccess.value = true
                 if !AuthManager.shared.hasPreference {
-                    UserDefaults.standard.set(true,
-                                              forKey: StringLiterals.UserDefaults.hasPreference)
+                    UserDefaultsManager.set(true, forKey: .hasPreference)
                 }
             case .reIssueJWT:
                 self.handleReissue {

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileSettingViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/View/ProfileSettingViewController.swift
@@ -82,7 +82,7 @@ extension ProfileSettingViewController {
                 NavigationUtils.navigateToSplash()
             } else {
                 self?.showServerErrorAlert {
-                    AuthManager.shared.removeToken()
+                    UserDefaultsManager.removeTokens()
                     NavigationUtils.navigateToSplash()
                 }
             }

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/SettingViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/SettingViewModel.swift
@@ -18,7 +18,7 @@ final class SettingViewModel: Serviceable {
             PostLogoutRequest(refreshToken: refreshToken)) { result in
                 switch result {
                 case .success:
-                    UserDefaultsManager.removeAll()
+                    UserDefaultsManager.resetAppUserDefaults()
                     AmplitudeManager.shared.reset()
                     self.onPostLogoutSuccess.value = true
                 case .reIssueJWT:

--- a/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/SettingViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Profile/ViewModel/SettingViewModel.swift
@@ -10,17 +10,15 @@ import UIKit
 final class SettingViewModel: Serviceable {
 
     var onPostLogoutSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
-    
+
     func postLogout() {
-        let refreshToken = UserDefaults.standard.string(forKey: StringLiterals.UserDefaults.refreshToken) ?? ""
+        let refreshToken = UserDefaultsManager.get(String.self, forKey: .refreshToken) ?? ""
+
         ACService.shared.authService.postLogout(
             PostLogoutRequest(refreshToken: refreshToken)) { result in
                 switch result {
                 case .success:
-                    for key in UserDefaults.standard.dictionaryRepresentation().keys {
-                        if key == StringLiterals.UserDefaults.hasSeenTutorial { continue }
-                        UserDefaults.standard.removeObject(forKey: key)
-                    }
+                    UserDefaultsManager.removeAll()
                     AmplitudeManager.shared.reset()
                     self.onPostLogoutSuccess.value = true
                 case .reIssueJWT:

--- a/ACON-iOS/ACON-iOS/Presentation/Splash/View/SplashViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Splash/View/SplashViewController.swift
@@ -10,15 +10,16 @@ import UIKit
 import AVFAudio
 
 class SplashViewController: BaseViewController {
-    
+
     // MARK: - UI Properties
-    
+
     private let splashView = SplashView()
-    
+
     private var player: AVAudioPlayer?
-    
+
+
     // MARK: - LifeCycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -29,7 +30,15 @@ class SplashViewController: BaseViewController {
             print("오디오 세션 설정 오류: \(error)")
         }
     }
-    
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if AuthManager.shared.needsTokenRefresh() {
+            refreshToken()
+        }
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(false)
         
@@ -44,12 +53,12 @@ class SplashViewController: BaseViewController {
             }
         }
     }
-    
+
     deinit {
         player?.stop()
         player = nil
     }
-    
+
     override func setHierarchy() {
         super.setHierarchy()
         
@@ -143,7 +152,7 @@ private extension SplashViewController {
 // MARK: - Splash Animation
 
 private extension SplashViewController {
-    
+
     func playSplashAnimation() {
         splashView.do {
             $0.splashLottieView.play()
@@ -151,7 +160,7 @@ private extension SplashViewController {
         fadeShadowImage()
         playSplashBGM()
     }
-    
+
     func fadeShadowImage() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
             UIView.animate(withDuration: 0.1) {
@@ -159,7 +168,7 @@ private extension SplashViewController {
             }
         }
     }
-    
+
     func playSplashBGM() {
         let audioSession = AVAudioSession.sharedInstance()
             
@@ -173,5 +182,33 @@ private extension SplashViewController {
             player?.play()
         }
     }
-    
+
+}
+
+
+// MARK: - Token refresh
+
+private extension SplashViewController {
+
+    func refreshToken() {
+        Task {
+            do {
+                let success = try await AuthManager.shared.handleTokenRefresh()
+                DispatchQueue.main.async {
+                    if success {
+                        print("❄️ 토큰 갱신 성공")
+                    } else {
+                        UserDefaultsManager.resetAppUserDefaults()
+                        NavigationUtils.navigateToSplash()
+                    }
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    UserDefaultsManager.resetAppUserDefaults()
+                    NavigationUtils.navigateToSplash()
+                }
+            }
+        }
+    }
+
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -753,7 +753,7 @@ private extension SpotListViewController {
         guard AuthManager.shared.hasToken else { return }
         guard !AuthManager.shared.hasVerifiedArea else { return }
         
-        let lastAlertTime = UserDefaultsManager.get(Date.self, forKey: .lastLocalVerificationAlertTime)
+        let lastAlertTime = UserDefaultsManager.get(Date.self, forKey: .lastLocalVerificationAlertDate)
         let now = Date()
         
         if let lastTime = lastAlertTime {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -753,7 +753,7 @@ private extension SpotListViewController {
         guard AuthManager.shared.hasToken else { return }
         guard !AuthManager.shared.hasVerifiedArea else { return }
         
-        let lastAlertTime = UserDefaults.standard.object(forKey: StringLiterals.UserDefaults.lastLocalVerificationAlertTime) as? Date
+        let lastAlertTime = UserDefaultsManager.get(Date.self, forKey: .lastLocalVerificationAlertTime)
         let now = Date()
         
         if let lastTime = lastAlertTime {

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/View/WithdrawalConfirmationViewController.swift
@@ -43,7 +43,7 @@ extension WithdrawalConfirmationViewController {
                 AmplitudeManager.shared.reset()
             } else {
                 self.showServerErrorAlert {
-                    AuthManager.shared.removeToken()
+                    UserDefaultsManager.removeTokens()
                     NavigationUtils.navigateToSplash()
                 }
             }

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/ViewModel/WithdrawalViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/ViewModel/WithdrawalViewModel.swift
@@ -8,17 +8,17 @@
 import Foundation
 
 final class WithdrawalViewModel: Serviceable {
-    
+
     var selectedOption: ObservablePattern<String> = ObservablePattern(nil)
     var inputText: ObservablePattern<String> = ObservablePattern(nil)
     var shouldDismissKeyboard: ObservablePattern<Bool> = ObservablePattern(false)
     var ectOption: ObservablePattern<Bool> = ObservablePattern(false)
-    
+
     let onSuccessPostWithdrawal: ObservablePattern<Bool> = ObservablePattern(nil)
-    
+
     func updateSelectedOption(_ option: String?) {
         selectedOption.value = option
-        
+
         if option == StringLiterals.Withdrawal.optionOthers {
             if let inputText = inputText.value, !inputText.isEmpty {
                 ectOption.value = true
@@ -32,7 +32,7 @@ final class WithdrawalViewModel: Serviceable {
             ectOption.value = false
         }
     }
-    
+
     func updateInputText(_ text: String?) {
         inputText.value = text
         
@@ -40,20 +40,17 @@ final class WithdrawalViewModel: Serviceable {
             ectOption.value = (text?.isEmpty == false)
         }
     }
-    
+
     func postWithdrawal() {
-        let refreshToken = UserDefaults.standard.string(forKey: StringLiterals.UserDefaults.refreshToken) ?? ""
-        
+        let refreshToken = UserDefaultsManager.get(String.self, forKey: .refreshToken) ?? ""
+
         guard let reasonText = selectedOption.value else { return }
 
         ACService.shared.withdrawalService.postWithdrawal(
             WithdrawalRequest(reason: reasonText, refreshToken: refreshToken)) { result in
             switch result {
             case .success:
-                for key in UserDefaults.standard.dictionaryRepresentation().keys {
-                    if key == StringLiterals.UserDefaults.hasSeenTutorial { continue }
-                    UserDefaults.standard.removeObject(forKey: key)
-                }
+                UserDefaultsManager.removeAll()
                 self.onSuccessPostWithdrawal.value = true
             case .reIssueJWT:
                 self.handleReissue { [weak self] in
@@ -68,5 +65,5 @@ final class WithdrawalViewModel: Serviceable {
             }
         }
     }
-}
 
+}

--- a/ACON-iOS/ACON-iOS/Presentation/Withdrawal/ViewModel/WithdrawalViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Withdrawal/ViewModel/WithdrawalViewModel.swift
@@ -50,7 +50,7 @@ final class WithdrawalViewModel: Serviceable {
             WithdrawalRequest(reason: reasonText, refreshToken: refreshToken)) { result in
             switch result {
             case .success:
-                UserDefaultsManager.removeAll()
+                UserDefaultsManager.resetAppUserDefaults()
                 self.onSuccessPostWithdrawal.value = true
             case .reIssueJWT:
                 self.handleReissue { [weak self] in


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #268

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->

### 1. UserDefaultsManager 구현
**구현 배경**
로그아웃/탈퇴 등의 상황에서 `UserDefaults.standard.dictionaryRepresentation` 를 순환하며 항목을 삭제하고 있었습니다.
그러나, 이는 시스템 정보도 삭제하기 때문에 로그아웃/탈퇴 후 언어가 바뀌는 등의 문제가 발생할 수 있습니다.

**결과**
UserDefaultsManager를 만들었습니다.
👉 앱의 keys만 안전하게 삭제 가능
👉 UserDefaults를 더 편하게 set, get, remove 가능


### 2. Splash에서 토큰 갱신

**구현 배경**
Refresh token이 만료되었을 경우)
-기존 로직: 앱 진입 -> API 호출 -> token error -> token refresh 실패 -> 로그인 화면으로 이동
-문제: 앱 진입 후 갑자기 로그인 화면으로 튕기는 UX적 불편감

**구현 상세**
Splash에서 미리 토큰 상태를 점검 및 갱신하여, 사용자 경험을 자연스럽게 유지했습니다.
- 앱 실행 시 UserDefaults에 저장된 마지막 토큰 갱신 시각 확인
- Access Token(3시간) 남은 시간이 30분 미만일 경우 Refresh Token API 호출
  (= 토큰 생성 후 2시간 30분(9000초) 지났을 때 refresh)

**결과**
<Access token 남은 시간 30분 이상>: 바로 앱 진입 (자동로그인)
<Access token 남은 시간 30분 미만 or 만료>: Refresh Token -> 앱 진입 (자동로그인)
<Refresh Token 만료>: 로그인 -> 앱 진입


## 📸 스크린샷
|token 남은시간| 다음화면 | 스크린샷|
|:--:|:--:|:--:|
|30분 이상 | 자동로그인|<img width="441" height="36" alt="image" src="https://github.com/user-attachments/assets/70785c89-9ca3-4807-8aa5-b5c923b420c0" />|
|30분 미만/만료 | 자동로그인 <br/> (토큰 갱신 주기 임의로 조정하여 테스트 완료)| <img width="433" height="79" alt="image" src="https://github.com/user-attachments/assets/5abc5b0e-137c-426a-a3f0-e43865d52cd3" /> |
|Refresh Token 만료 | 로그인 화면 <br/> (임의로 토큰 삭제하여 테스트 완료) | <img width="416" height="26" alt="image" src="https://github.com/user-attachments/assets/c695f92e-4beb-415c-998d-cc3d7443dff8" /> |

## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #268 
